### PR TITLE
Improve cache invalidation for onflow/flow repo

### DIFF
--- a/app/cms/github-webhook.server.test.ts
+++ b/app/cms/github-webhook.server.test.ts
@@ -101,6 +101,41 @@ test("it returns special paths for index documents", () => {
   )
 })
 
+test("it returns keys for the onflow repoo", () => {
+  const event: any = {
+    ref: "refs/heads/master",
+    repository: {
+      name: "flow",
+      owner: { login: "onflow" },
+    },
+    commits: [
+      {
+        added: [],
+        removed: [],
+        modified: [
+          "docs/content/dapp-development/index.md",
+          "docs/content/dapp-development/in-dapp-payments.mdx",
+        ],
+      },
+    ],
+  }
+
+  const result = pushEventCacheKeysToInvalidate(event)
+  const keyPrefix = `onflow:flow:master:docs/content/dapp-development/`
+
+  expect(result.docCollectionStatus).toBe("match")
+  expect(result.cacheKeysToInvalidate).toEqual(
+    new Set([
+      `${keyPrefix}::compiled`,
+      `${keyPrefix}::downloaded`,
+      `${keyPrefix}:index:compiled`,
+      `${keyPrefix}:index:downloaded`,
+      `${keyPrefix}:in-dapp-payments:compiled`,
+      `${keyPrefix}:in-dapp-payments:downloaded`,
+    ])
+  )
+})
+
 test("it clears the expected cache keys when files are removed", () => {
   const event: any = {
     ...exampleEvent,

--- a/app/constants/doc-collections.server.ts
+++ b/app/constants/doc-collections.server.ts
@@ -339,7 +339,7 @@ export const docCollections: Record<string, DocCollection> = {
       owner: "onflow",
       name: "flow",
       branch: "master",
-      rootPath: "docs/content/dapp-development",
+      rootPath: "docs/content/dapp-development/",
     },
     manifest: {
       displayName: "DApp Development",


### PR DESCRIPTION
cache invalidation logic had assumed a repo and branch only mapped to a single doc collection, which didn't work right with onflow/flow