### PR TITLE
Fix network details page

### DIFF
--- a/app/cms/utils/fetch-network-status.tsx
+++ b/app/cms/utils/fetch-network-status.tsx
@@ -8,10 +8,7 @@ export async function fetchNetworkStatus() {
     headers: {
       Authorization: `OAuth ${key}`,
     },
-  }).then((r) => r.json())
-
-  const status = response.filter(
-    (network: any) => network.name !== "Flow Canarynet" // Filter out canarynet for now until we have sporks data.
-  )
-  return status as StatuspageApiResponse[]
+  })
+  const data = await response.json()
+  return data as StatuspageApiResponse[]
 }

--- a/app/data/networks.ts
+++ b/app/data/networks.ts
@@ -1,0 +1,47 @@
+export type Network = {
+  /**
+   * The statuspage.io component ID for this network
+   * @see {@link https://developer.statuspage.io/#operation/getPagesPageIdComponents}
+   */
+  componentId: string
+
+  /**
+   * A unique id for the network. This should match the identifier
+   * used by sporks (i.e. https://raw.githubusercontent.com/onflow/flow/master/sporks.json)
+   */
+  id: string
+
+  /**
+   * The user-facing display title for the network.
+   */
+  title: string
+
+  /**
+   * The URL path identifier for this network
+   * (i.e. "flow-testnet" means the URL for this network details will be
+   * "/netwoorks/flow-testnet")
+   */
+  urlPath: string
+}
+
+export const networks: Network[] = [
+  {
+    componentId: "fqvhhbc3hdw8",
+    id: "mainnet",
+    title: "Flow Mainnet",
+    urlPath: "flow-mainnet",
+  },
+  {
+    componentId: "g9d7vtywpdfq",
+    id: "testnet",
+    title: "Flow Testnet",
+    urlPath: "flow-testnet",
+  },
+  // Exclude canarynet for now until we have sporks data.
+  // {
+  //   componentId: "s4z9n7p9pm3s",
+  //   id: "canarynet",
+  //   title: "Flow Canarynet",
+  //   urlPath: "flow-canarynet",
+  // },
+]

--- a/app/ui/design-system/src/lib/Pages/NetworkDetailPage/index.tsx
+++ b/app/ui/design-system/src/lib/Pages/NetworkDetailPage/index.tsx
@@ -23,15 +23,13 @@ import { SocialLinksSignupProps } from "../../Components/SocialLinksSignup"
 export type NetworkDetailPageProps = SocialLinksSignupProps & {
   featuredArticle: Article
   networkName: string
-  networkStatuses: StatuspageApiResponse[]
+  status?: StatuspageApiResponse
   pastSporks: SporksCardProps[]
+  networks: Array<{
+    link: string
+    name: string
+  }>
 }
-
-export const getNetworkNameFromParam = (param: string) =>
-  param
-    .split("-")
-    .map((name) => name.slice(0, 1).toUpperCase() + name.slice(1))
-    .join(" ")
 
 const NetworkDetailPage = ({
   discordUrl,
@@ -39,21 +37,11 @@ const NetworkDetailPage = ({
   featuredArticle,
   githubUrl,
   networkName,
-  networkStatuses,
+  networks,
   pastSporks,
+  status,
   twitterUrl,
 }: NetworkDetailPageProps) => {
-  const convertedName = getNetworkNameFromParam(networkName)
-  const defaultIndex = networkStatuses.findIndex((object) => {
-    return object.name === convertedName
-  })
-  const [selectedNetworkIndex, setSelectedNetworkIndex] = useState(defaultIndex)
-  const tabs = networkStatuses.map((network: StatuspageApiResponse) => ({
-    name: network.name,
-    link: `/network/${network.name.replace(" ", "-").toLowerCase()}`,
-  }))
-  const currentNetwork = networkStatuses[selectedNetworkIndex]
-
   return (
     <PageBackground>
       <PageSections divided={false}>
@@ -66,15 +54,13 @@ const NetworkDetailPage = ({
               <ChevronLeftIcon /> Network
             </AppLink>
           </div>
-          <TabMenu tabs={tabs} onTabChange={setSelectedNetworkIndex} centered />
+          <TabMenu tabs={networks} centered />
           <div className="text-h3 md:text-h1 mt-16 mb-14 pl-4 md:text-center md:text-5xl">
-            {currentNetwork?.name}
+            {networkName}
           </div>
           <NetworkDetailsCard
             status={
-              currentNetwork?.status === "operational"
-                ? "Healthy"
-                : "Under Maintenance"
+              status?.status === "operational" ? "Healthy" : "Under Maintenance"
             }
             statusLink="https://status.onflow.org"
             version="33"
@@ -93,7 +79,7 @@ const NetworkDetailPage = ({
               Upcoming Spork
             </HeaderWithLink>
             <SporksCard
-              heading={currentNetwork?.name || ""}
+              heading={networkName}
               timestamp={endOfWeek(new Date()).toString()}
               sporkMetadata={{
                 accessNode: "access-001.mainnet15.nodes.onflow.org:9000",
@@ -139,7 +125,7 @@ const NetworkDetailPage = ({
             </div>
           </div>
         </PageSection>
-        <PageSection>
+        {/* <PageSection>
           <div className="container">
             <Callout
               heading="Spork FAQ"
@@ -148,7 +134,7 @@ const NetworkDetailPage = ({
               ctaLink="https://flow.com"
             />
           </div>
-        </PageSection>
+        </PageSection> */}
       </PageSections>
       <SocialLinksSignup
         discordUrl={discordUrl}

--- a/app/ui/design-system/src/lib/Pages/NetworkDetailPage/index.tsx
+++ b/app/ui/design-system/src/lib/Pages/NetworkDetailPage/index.tsx
@@ -1,8 +1,6 @@
 import { endOfWeek } from "date-fns"
-import { useState } from "react"
 import { ReactComponent as ChevronLeftIcon } from "../../../../images/arrows/chevron-left"
 import {
-  Callout,
   NetworkDetailsCard,
   Pagination,
   SocialLinksSignup,


### PR DESCRIPTION
The network details page tab navigation wasn't working correctly after initial server-side page load. The "networkStatus"  data was not being updated properly. This is because the `tabs` we were passing into the `TabMenu` included `link` properties, which never triggers the `onTabChange` callback - it just navigates to the page. 

This fixes that and simplifies a lot of the logic by adding a predefined array of networks (`app/data/networks.ts`) rather than relying on the statuspage.io response to extract the data based on the title. 