### PR TITLE
Add health checks for docker services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,17 +53,32 @@ services:
   app-css:
     <<: *app-defaults
     command: ["yarn", "run", "dev:css"]
+    healthcheck:
+      # service is healthy once main.css has been generated
+      test: bash  -c "[ -f /opt/next-docs/app/main.css ]"
+      interval: 10s
+      retries: 5
+      start_period: 5s
     # postcss exits without an stdin
     # See: https://github.com/postcss/postcss-cli/pull/424
     tty: true
     depends_on:
-      - app-yarn
+      app-yarn:
+        condition: service_completed_successfully
   # Watches for SVG changes and recreates their components as needed.
   app-svg:
     <<: *app-defaults
     command: ["yarn", "run", "dev:svg"]
+    healthcheck:
+      # "dev:svg" executes "touch /tmp/svgs-generated" after each run, so we
+      # check that this file has been updated within the last 1 minute
+      test: test `find /tmp/svgs-generated -type f -mmin -1`
+      interval: 5s
+      retries: 5
+      start_period: 15s
     depends_on:
-      - app-yarn  # should probably use some sort of "wait-for" here instead.
+      app-yarn:
+        condition: service_completed_successfully
   # The main application
   app:
     <<: *app-defaults
@@ -72,11 +87,23 @@ services:
       - "3000:3000" # Web app port
       - "8002:8002" # Websocket for live-reload
     depends_on:
-      - app-css
-      - app-svg
+      app-css:
+        condition: service_healthy
+      app-svg:
+        condition: service_healthy
   storybook:
     <<: *app-defaults
     profiles: ["storybook"]
-    command: ["yarn", "run", "start-storybook", "-p", "6006", "--quiet", "--no-open", "--disable-telemetry"]
+    command:
+      [
+        "yarn",
+        "run",
+        "start-storybook",
+        "-p",
+        "6006",
+        "--quiet",
+        "--no-open",
+        "--disable-telemetry",
+      ]
     ports:
       - "6006:6006"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev": "run-p dev:*",
     "dev:css": "yarn generate:css --watch",
     "dev:remix": "remix dev",
-    "dev:svg": "chokidar --silent --initial \"./app/ui/design-system/images/**/*.svg\" -c \"yarn svgr --silent --template svgr/template.js --filename-case kebab --out-dir ./app/ui/design-system/images ./app/ui/design-system/images\"",
+    "dev:svg": "chokidar --silent --initial \"./app/ui/design-system/images/**/*.svg\" -c \"yarn svgr --silent --template svgr/template.js --filename-case kebab --out-dir ./app/ui/design-system/images ./app/ui/design-system/images && touch /tmp/svgs-generated\"",
     "format:app": "prettier --write app",
     "format:check:app": "prettier --check app",
     "generate:css": "postcss ./app/ui/design-system/styles/main.css -o app/main.css",


### PR DESCRIPTION
Adds health checks to our `docker-compose.yml`. From now on, the `app` won't start until both `app-css` and `app-svg` have passed their health checks. And those services won't start until `app-yarn` runs successfully. 