### PR TITLE
Use preset icons for LinkCard2Column, TutorialCard

### DIFF
--- a/app/data/articles/index.ts
+++ b/app/data/articles/index.ts
@@ -1,6 +1,5 @@
 import { FeaturedArticleCardProps } from "~/ui/design-system/src/lib/Components/FeaturedArticleCard"
 import { TutorialCardProps } from "~/ui/design-system/src/lib/Components/TutorialCard"
-import CodeIcon from "~/ui/design-system/images/content/code.svg"
 
 export const redSquirrelGetStartedArticle: TutorialCardProps = {
   heading: "Getting started on Flow with a RedSquirrel NFT",
@@ -66,7 +65,7 @@ export const FCLQuickstartNuxtJs: TutorialCardProps = {
   tags: ["quickstart", "beginner"],
   description: `Everything you need to build a web3 project with the Vue, NuxtJS, and the Flow Client Library (FCL).`,
   link: "https://github.com/brunogonzales/fcl-nuxt-starter",
-  imageUri: CodeIcon,
+  imageType: "code",
 }
 
 export const FCLQuickstartSvelteKit: TutorialCardProps = {
@@ -74,7 +73,7 @@ export const FCLQuickstartSvelteKit: TutorialCardProps = {
   tags: ["quickstart", "beginner"],
   description: `Everything you need to build a web3 project with Svelte, SvelteKit and the Flow Client Library (FCL).`,
   link: "https://github.com/muttoni/fcl-sveltekit-quickstart",
-  imageUri: CodeIcon,
+  imageType: "code",
 }
 
 export const flowNFTPetStore: TutorialCardProps = {

--- a/app/data/pages/getting-started.ts
+++ b/app/data/pages/getting-started.ts
@@ -1,5 +1,3 @@
-import CadenceIcon from "~/ui/design-system/images/tools/tool-cadence.svg"
-import FCLIcon from "~/ui/design-system/images/tools/tool-fcl.svg"
 import { ContentNavigationListProps } from "~/ui/design-system/src/lib/Components/ContentNavigationList"
 import { FeaturedArticleCardProps } from "~/ui/design-system/src/lib/Components/FeaturedArticleCard"
 import { LandingHeaderProps } from "~/ui/design-system/src/lib/Components/LandingHeader"
@@ -147,14 +145,14 @@ export const linkCard2ColumnItems: LinkCard2ColumnProps = {
       description:
         "Cadence is a resource-oriented programming language that introduces new features to smart contract programming.",
       href: "/cadence",
-      icon: CadenceIcon,
+      iconType: "cadence",
     },
     {
       title: "Flow Client Library",
       description:
         "The Flow Client Library (FCL) JS is a package used to interact with user wallets, dapps, and the blockchain.",
       href: "/tools/fcl-js",
-      icon: FCLIcon,
+      iconType: "fcl",
     },
   ],
 }

--- a/app/data/pages/home.tsx
+++ b/app/data/pages/home.tsx
@@ -6,8 +6,6 @@ import {
   LinkCard3ColumnItems,
 } from "~/ui/design-system/src"
 import { ContentNavigationListProps } from "~/ui/design-system/src/lib/Components/ContentNavigationList"
-import PlaygroundIcon from "../../ui/design-system/images/misc/playground-default.png"
-import FCLIcon from "../../ui/design-system/images/tools/tool-fcl.svg"
 import { metadata } from "../metadata"
 
 const homepageStartProjectData: LinkCard2ColumnProps = {
@@ -24,13 +22,13 @@ const homepageStartProjectData: LinkCard2ColumnProps = {
       description:
         "Build a front-end and run your first transactions on the Flow blockchain within minutes.",
       href: "/tools/fcl-js/tutorials/flow-app-quickstart/",
-      icon: FCLIcon,
+      iconType: "fcl",
     },
     {
       title: "Learn Smart Contracts",
       description:
         "A series of tutorials that explain how to build your first smart contracts with our programming language, Cadence.",
-      icon: PlaygroundIcon,
+      iconType: "playground",
       links: [
         {
           href: "/cadence/tutorial/02-hello-world/",

--- a/app/ui/design-system/src/lib/Components/LinkCard2Column/LinkCard2Column.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/LinkCard2Column/LinkCard2Column.stories.tsx
@@ -1,19 +1,9 @@
 import { Meta, Story } from "@storybook/react"
-import { renderToStaticMarkup } from "react-dom/server"
 import { LinkCard2Column, LinkCard2ColumnProps } from "."
-import { ReactComponent as CadenceIcon } from "../../../../images/tools/tool-cadence-gradient"
-
-export const svgToDataUri = (
-  element: Parameters<typeof renderToStaticMarkup>[0]
-) => {
-  const svgString = encodeURIComponent(renderToStaticMarkup(element))
-  return `data:image/svg+xml,${svgString}`
-}
 
 export default {
   component: LinkCard2Column,
   title: "Components/LinkCard2Column",
-  excludeStories: ["svgToDataUri"],
   parameters: {
     layout: "centered",
   },
@@ -37,13 +27,13 @@ Default.args = {
       description:
         "A package used to interact with user wallets and the Flow blockchain.",
       href: "https://www.onflow.org",
-      icon: svgToDataUri(<CadenceIcon />),
+      iconType: "cadence",
     },
     {
       title: "Internal single link example",
       description: "This is an example of an item with a single internal link.",
       href: "#create-non-fungible-token",
-      icon: "https://avatars.githubusercontent.com/u/62387156?s=64&v=4",
+      iconType: "fcl",
     },
     {
       title: "Create Non Fungible Token",

--- a/app/ui/design-system/src/lib/Components/LinkCard2Column/LinkCard2ColumnItem.tsx
+++ b/app/ui/design-system/src/lib/Components/LinkCard2Column/LinkCard2ColumnItem.tsx
@@ -3,44 +3,47 @@ import { ReactComponent as ExternalLinkIcon } from "../../../../images/content/e
 import AppLink from "../AppLink"
 import { isLinkExternal } from "../../utils/isLinkExternal"
 import { LinkCard2ColumnItemContainer } from "./LinkCard2ColumnItemContainer"
+import { LinkCardIconType, LINK_CARD_ICONS } from "./icons"
 
 export type LinkCard2ColumnItemBaseProps = {
   description: string
-  icon?: string
+  iconType?: LinkCardIconType
   iconAltText?: string
   title: string
+  homePage?: boolean
 }
 
-export type LinkCard2ColumnItemSingleLinkProps =
-  LinkCard2ColumnItemBaseProps & {
+export type LinkCard2ColumnItemSingleLinkProps = {
+  href: string
+  links?: never
+}
+
+export type LinkCard2ColumnItemMultipleLinksProps = {
+  href?: never
+  links?: Array<{
     href: string
-    links?: never
-    homePage?: boolean
-  }
+    title: string
+  }>
+}
 
-export type LinkCard2ColumnItemMultipleLinksProps =
-  LinkCard2ColumnItemBaseProps & {
-    href?: never
-    links?: Array<{
-      href: string
-      title: string
-    }>
-    homePage?: boolean
-  }
-
-export type LinkCard2ColumnItemProps =
+export type LinkCard2ColumnItemLinkProps =
   | LinkCard2ColumnItemSingleLinkProps
   | LinkCard2ColumnItemMultipleLinksProps
+
+export type LinkCard2ColumnItemProps = LinkCard2ColumnItemBaseProps &
+  LinkCard2ColumnItemLinkProps
 
 export function LinkCard2ColumnItem({
   description,
   href,
-  icon,
   iconAltText = "",
   links,
   title,
   homePage,
+  iconType,
 }: LinkCard2ColumnItemProps) {
+  const icon = iconType ? LINK_CARD_ICONS[iconType] : undefined
+
   return (
     <LinkCard2ColumnItemContainer
       href={links?.length ? undefined : href}

--- a/app/ui/design-system/src/lib/Components/LinkCard2Column/icons.ts
+++ b/app/ui/design-system/src/lib/Components/LinkCard2Column/icons.ts
@@ -1,0 +1,11 @@
+import PlaygroundIcon from "~/ui/design-system/images/misc/playground-default.png"
+import FCLIcon from "~/ui/design-system/images/tools/tool-fcl.svg"
+import CadenceIcon from "~/ui/design-system/images/tools/tool-cadence.svg"
+
+export const LINK_CARD_ICONS = {
+  cadence: CadenceIcon,
+  fcl: FCLIcon,
+  playground: PlaygroundIcon,
+} as const
+
+export type LinkCardIconType = keyof typeof LINK_CARD_ICONS

--- a/app/ui/design-system/src/lib/Components/TutorialCard/icons.ts
+++ b/app/ui/design-system/src/lib/Components/TutorialCard/icons.ts
@@ -1,0 +1,9 @@
+import DefaultImage from "~/ui/design-system/images/misc/article-default.svg"
+import CodeIcon from "~/ui/design-system/images/content/code.svg"
+
+export const TUTORIAL_CARD_ICONS = {
+  default: DefaultImage,
+  code: CodeIcon,
+} as const
+
+export type TutorialCardIconType = keyof typeof TUTORIAL_CARD_ICONS

--- a/app/ui/design-system/src/lib/Components/TutorialCard/index.tsx
+++ b/app/ui/design-system/src/lib/Components/TutorialCard/index.tsx
@@ -3,21 +3,30 @@ import { forwardRef } from "react"
 import { ReactComponent as CalendarIcon } from "../../../../images/action/date-calendar"
 import { ReactComponent as UserIcon } from "../../../../images/arrows/user"
 import { ReactComponent as TutorialIcon } from "../../../../images/content/drafting-tools"
-import DefaultImage from "../../../../images/misc/article-default"
 import { User } from "../../interfaces"
 import Tag from "../Tag"
+import { TutorialCardIconType, TUTORIAL_CARD_ICONS } from "./icons"
 
-export type TutorialCardProps = {
+export type TutorialCardPropsImageUri = {
+  author?: User
   className?: string
-  heading: string
-  tags: string[]
   description: string
+  heading: string
+  imageUri?: string
   lastUpdated?: string
   level?: string
-  imageUri?: any
   link: string
-  author?: User
+  tags: string[]
 }
+
+export type TutorialCardPropsImagePreset = TutorialCardPropsImageUri & {
+  imageUri: never
+  imageType: TutorialCardIconType
+}
+
+export type TutorialCardProps =
+  | TutorialCardPropsImagePreset
+  | TutorialCardPropsImageUri
 
 const TutorialCard = forwardRef<HTMLAnchorElement, TutorialCardProps>(
   (
@@ -28,12 +37,17 @@ const TutorialCard = forwardRef<HTMLAnchorElement, TutorialCardProps>(
       description,
       lastUpdated,
       level,
-      imageUri = DefaultImage,
       link,
       author,
+      ...props
     },
     ref
   ) => {
+    const imageUri =
+      ("imageType" in props
+        ? TUTORIAL_CARD_ICONS[props.imageType]
+        : props.imageUri) || TUTORIAL_CARD_ICONS.default
+
     return (
       // TODO: switch to AppLink
       <a

--- a/app/ui/design-system/src/lib/Pages/GettingStartedPage/GettingStartedPage.stories.tsx
+++ b/app/ui/design-system/src/lib/Pages/GettingStartedPage/GettingStartedPage.stories.tsx
@@ -1,9 +1,5 @@
 import { Meta, Story } from "@storybook/react"
 import { GettingStartedPage, GettingStartedPageProps } from "."
-import { ReactComponent as CadenceIcon } from "../../../../images/tools/tool-cadence"
-import { ReactComponent as FCLIcon } from "../../../../images/tools/tool-fcl"
-
-import { svgToDataUri } from "../../Components/LinkCard2Column/LinkCard2Column.stories"
 
 export const Icon1 = () => (
   <svg
@@ -100,10 +96,16 @@ export const Icon3 = () => (
 )
 
 const gettingStartedPageData = {
+  discordUrl: "https://onflow.org/discord",
+  discourseUrl: "https://forum.onflow.org/",
+  githubUrl: "https://github.com/onflow",
+  twitterUrl: "https://twitter.com/flow_blockchain",
   landingHeaderItems: {
     buttonText: "Button Text",
     buttonUrl: "#changeme",
     callout: "Featured callout here two lines",
+    discordUrl: "https://onflow.org/discord",
+    githubUrl: "https://github.com/onflow",
     description:
       "Lorem ipsum dolor sit amet proin gravida lorem ipsum dolor sit.",
     title: "Getting Started",
@@ -206,14 +208,14 @@ const gettingStartedPageData = {
         description:
           "A package used to interact with user wallets and the Flow blockchain.",
         href: "https://www.onflow.org",
-        icon: svgToDataUri(<CadenceIcon />),
+        iconType: "cadence",
       },
       {
         title: "Flow Client Library",
         description:
           "A package used to interact with user wallets and the Flow blockchain.",
         href: "#create-non-fungible-token",
-        icon: svgToDataUri(<FCLIcon />),
+        iconType: "fcl",
       },
     ],
   },


### PR DESCRIPTION
Instead of specifying the icon `src` directly this creates a set of "preset" icons to choose from instead for the `LinkCard2Column` component and the `TutorialCard` component. This should fix some issues with images not being included in the bundles because remix is not identifying that they are being used.

There's still some other components to do this for but wanted to get a PR for these initial 2 first to solicit any feedback first.