### PR TITLE
Fix /networks page

### DIFF
--- a/app/routes/network/index.tsx
+++ b/app/routes/network/index.tsx
@@ -3,13 +3,13 @@ import { useLoaderData } from "@remix-run/react"
 // import { fetchDiscordAnnouncements } from "~/cms/utils/fetch-discord"
 import { fetchNetworkStatus } from "~/cms/utils/fetch-network-status"
 import { fetchSporks } from "~/cms/utils/fetch-sporks"
-import { getMetaTitle } from "~/utils/seo"
+import { featuredArticle } from "~/data/pages/network"
 import NetworkPage, {
   NetworkPageProps,
 } from "~/ui/design-system/src/lib/Pages/NetworkPage"
+import { getMetaTitle } from "~/utils/seo"
 import { externalLinks } from "../../data/external-links"
-
-import { featuredArticle } from "~/data/pages/network"
+import { networks } from "../../data/networks"
 
 export const meta: MetaFunction = () => ({
   title: getMetaTitle("Network status"),
@@ -26,9 +26,14 @@ export const loader: LoaderFunction = async (): Promise<LoaderData> => {
     discourseUrl: externalLinks.discourse,
     featuredArticle,
     githubUrl: externalLinks.github,
-    networkStatuses,
-    pastSporks,
     twitterUrl: externalLinks.twitter,
+    networks: networks.map(({ componentId, id, title, urlPath }) => ({
+      lastSporkDate: pastSporks[id]?.[0]?.timestamp as string | undefined,
+      name: title,
+      link: `/network/${urlPath}`,
+      status: networkStatuses.find((status) => status.id === componentId)
+        ?.status,
+    })),
   }
 }
 
@@ -43,8 +48,7 @@ export default function Page() {
       discourseUrl={data.discourseUrl}
       featuredArticle={data.featuredArticle}
       githubUrl={data.githubUrl}
-      networkStatuses={data.networkStatuses}
-      pastSporks={data.pastSporks}
+      networks={data.networks}
       twitterUrl={data.twitterUrl}
     />
   )

--- a/app/ui/design-system/src/lib/Pages/NetworkPage/index.tsx
+++ b/app/ui/design-system/src/lib/Pages/NetworkPage/index.tsx
@@ -1,5 +1,4 @@
 import {
-  // AnnouncementCard,
   NetworkCard,
   // NetworkDiscordCard,
   SocialLinksSignup,
@@ -8,19 +7,23 @@ import { AnnouncementCardProps } from "../../Components/AnnouncementCard"
 import { FeaturedArticle } from "../../Components/FeaturedArticleSlider"
 // import { HeaderWithLink } from "../../Components/HeaderWithLink"
 import { NetworkDiscordCardProps } from "../../Components/NetworkDiscordCard"
-import { Article, StatuspageApiResponse } from "../../interfaces"
+import { SocialLinksSignupProps } from "../../Components/SocialLinksSignup"
+import { Article } from "../../interfaces"
+import { dateYYYYMMDD } from "../../utils/dates"
 import PageBackground from "../shared/PageBackground"
 import PageSection from "../shared/PageSection"
 import PageSections from "../shared/PageSections"
-import { dateYYYYMMDD } from "../../utils/dates"
-import { SocialLinksSignupProps } from "../../Components/SocialLinksSignup"
 
 export type NetworkPageProps = SocialLinksSignupProps & {
   announcementCards?: AnnouncementCardProps[]
   discordNetworkCards?: NetworkDiscordCardProps[]
   featuredArticle: Article
-  networkStatuses: StatuspageApiResponse[]
-  pastSporks: any
+  networks: Array<{
+    lastSporkDate?: string
+    link: string
+    name: string
+    status?: string
+  }>
 }
 
 const NetworkPage = ({
@@ -28,8 +31,7 @@ const NetworkPage = ({
   discourseUrl,
   featuredArticle,
   githubUrl,
-  networkStatuses,
-  pastSporks,
+  networks,
   twitterUrl,
 }: NetworkPageProps) => (
   <PageBackground gradient="network">
@@ -38,25 +40,22 @@ const NetworkPage = ({
         <div className="container">
           <h1 className="text-h1 pt-28 md:pt-[212px]">Network status</h1>
           <div className="mt-20 flex flex-col gap-4 md:gap-6">
-            {networkStatuses.map(({ name, status }: StatuspageApiResponse) => {
-              const convertedName: string = name.split(" ")[1]!.toLowerCase()
-              return (
-                <div key={name}>
-                  <NetworkCard
-                    networkName={name}
-                    status={
-                      status === "operational" ? "Healthy" : "Under Maintenance"
-                    }
-                    version="33"
-                    lastSporkDate={dateYYYYMMDD(
-                      pastSporks[convertedName][0].timestamp
-                    )}
-                    nextSporkDate="TBD"
-                    link={`/network/${name.toLowerCase().replace(" ", "-")}`}
-                  />
-                </div>
-              )
-            })}
+            {networks.map(({ name, lastSporkDate, link, status }) => (
+              <div key={name}>
+                <NetworkCard
+                  networkName={name}
+                  status={
+                    status === "operational" ? "Healthy" : "Under Maintenance"
+                  }
+                  version="33"
+                  lastSporkDate={
+                    lastSporkDate ? dateYYYYMMDD(lastSporkDate) : ""
+                  }
+                  nextSporkDate="TBD"
+                  link={`/network/${name.toLowerCase().replace(" ", "-")}`}
+                />
+              </div>
+            ))}
           </div>
         </div>
       </PageSection>


### PR DESCRIPTION
It appears I broke the /networks page when I adjusted the /networks/$networkName page recently to use the predefined list of networks in app/data/networks.ts. So this updates the overview page to use that data as well.