### PR TITLE
Fix tool-default.svg icon usage

### DIFF
--- a/app/ui/design-system/images/tools/tool-default-override.tsx
+++ b/app/ui/design-system/images/tools/tool-default-override.tsx
@@ -1,0 +1,106 @@
+import {} from "@remix-run/react"
+import * as React from "react"
+import { useId } from "../../src/lib/utils/useId"
+
+/**
+ * This should be use in place of the SVGR-generated SvgToolDefault icon in
+ * order to:
+ * 1. Provide dark-mode customizations
+ * 2. Ensure each instance of this component uses it's own filter IDs. Otherwise
+ *    rendering multiple instances at once on the screen can cause hover effects
+ *    on one instance to carry over into all other instances.
+ *
+ * If tool-default.svg is updated, this file should be updated appropriately!
+ */
+const SvgToolDefaultOverride = (
+  props: React.ComponentPropsWithoutRef<"svg">
+) => {
+  const id = useId()
+
+  return (
+    <svg
+      viewBox="0 0 250 250"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <g filter={`url(#tool-default_svg__a-${id})`}>
+        <rect
+          width={250}
+          height={250}
+          rx={16}
+          fill={`url(#tool-default_svg__b-${id})`}
+          fillOpacity={0.33}
+        />
+      </g>
+      <path
+        d="M92.429 151.857 65 124.429 92.429 97M113.857 153.143 136.571 97M157.571 97 185 124.429l-27.429 27.428"
+        stroke="#2F353F"
+        strokeWidth={14}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="dark:stroke-primary-gray-200"
+      />
+      <defs>
+        <linearGradient
+          id={`tool-default_svg__b-${id}`}
+          x1={37.698}
+          y1={-19.841}
+          x2={250}
+          y2={250}
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#fff" />
+          <stop offset={1} stopColor="#fff" stopOpacity={0} />
+        </linearGradient>
+        <filter
+          id={`tool-default_svg__a-${id}`}
+          x={-49.016}
+          y={-49.016}
+          width={348.032}
+          height={348.032}
+          filterUnits="userSpaceOnUse"
+          colorInterpolationFilters="sRGB"
+        >
+          <feFlood floodOpacity={0} result="BackgroundImageFix" />
+          <feGaussianBlur in="BackgroundImage" stdDeviation={24.508} />
+          <feComposite
+            in2="SourceAlpha"
+            operator="in"
+            result="effect1_backgroundBlur_326_6545"
+          />
+          <feBlend
+            in="SourceGraphic"
+            in2="effect1_backgroundBlur_326_6545"
+            result="shape"
+          />
+          <feColorMatrix
+            in="SourceAlpha"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+            result="hardAlpha"
+          />
+          <feOffset dx={3.18} dy={3.18} />
+          <feGaussianBlur stdDeviation={2.5} />
+          <feComposite in2="hardAlpha" operator="arithmetic" k2={-1} k3={1} />
+          <feColorMatrix values="0 0 0 0 0.928409 0 0 0 0 0.978523 0 0 0 0 1 0 0 0 0.2 0" />
+          <feBlend in2="shape" result="effect2_innerShadow_326_6545" />
+          <feColorMatrix
+            in="SourceAlpha"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+            result="hardAlpha"
+          />
+          <feOffset dx={-3.18} dy={-3.18} />
+          <feGaussianBlur stdDeviation={2.5} />
+          <feComposite in2="hardAlpha" operator="arithmetic" k2={-1} k3={1} />
+          <feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0" />
+          <feBlend
+            in2="effect2_innerShadow_326_6545"
+            result="effect3_innerShadow_326_6545"
+          />
+        </filter>
+      </defs>
+    </svg>
+  )
+}
+export const ReactComponent = SvgToolDefaultOverride
+export default SvgToolDefaultOverride

--- a/app/ui/design-system/src/lib/Components/InternalSidebarDropdownMenu/icons.ts
+++ b/app/ui/design-system/src/lib/Components/InternalSidebarDropdownMenu/icons.ts
@@ -2,7 +2,7 @@ import { ReactComponent as CadenceIcon } from "../../../../images/tools/tool-cad
 import { ReactComponent as CadenceGradientIcon } from "../../../../images/tools/tool-cadence-gradient"
 import { ReactComponent as CliIcon } from "../../../../images/tools/tool-cli"
 import { ReactComponent as CliGradientIcon } from "../../../../images/tools/tool-cli-gradient"
-import { ReactComponent as DefaultIcon } from "../../../../images/tools/tool-default"
+import { ReactComponent as DefaultIcon } from "../../../../images/tools/tool-default-override"
 import { ReactComponent as EmulatorIcon } from "../../../../images/tools/tool-emulator"
 import { ReactComponent as EmulatorGradientIcon } from "../../../../images/tools/tool-emulator-gradient"
 import { ReactComponent as FclIcon } from "../../../../images/tools/tool-fcl"

--- a/app/ui/design-system/src/lib/utils/useId.ts
+++ b/app/ui/design-system/src/lib/utils/useId.ts
@@ -1,0 +1,55 @@
+import * as React from "react"
+import { useIsomorphicLayoutEffect } from "./useIsomorphicLayoutEffect"
+
+let serverHandoffComplete = false
+let id = 0
+function genId() {
+  return ++id
+}
+
+/**
+ * Autogenerate stable IDs across re-renders
+ *
+ * Taken from this Reach UI implementation:
+ * https://github.com/reach/reach-ui/blob/dev/packages/auto-id/src/auto-id.ts
+ *
+ * This should be removed when we upgrade to React 18 in favor of the new
+ * built-in `useId` hook!
+ */
+function useId(providedId?: number | string | undefined | null) {
+  // @ts-expect-error
+  if (typeof React.useId === "function") {
+    console.warn(
+      "Please remove the custom `useId` implementation and switch to the built-in React version!"
+    )
+  }
+
+  // If this instance isn't part of the initial render, we don't have to do the
+  // double render/patch-up dance. We can just generate the ID and return it.
+  const initialId = providedId ?? (serverHandoffComplete ? genId() : null)
+  const [id, setId] = React.useState(initialId)
+
+  useIsomorphicLayoutEffect(() => {
+    if (id === null) {
+      // Patch the ID after render. We do this in `useLayoutEffect` to avoid any
+      // rendering flicker, though it'll make the first render slower (unlikely
+      // to matter, but you're welcome to measure your app and let us know if
+      // it's a problem).
+      setId(genId())
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  React.useEffect(() => {
+    if (serverHandoffComplete === false) {
+      // Flag all future uses of `useId` to skip the update dance. This is in
+      // `useEffect` because it goes after `useLayoutEffect`, ensuring we don't
+      // accidentally bail out of the patch-up dance prematurely.
+      serverHandoffComplete = true
+    }
+  }, [])
+
+  return providedId ?? id ?? undefined
+}
+
+export { useId }


### PR DESCRIPTION
This fixes an issue where rendering multiple instances of the tool-default.svg icon at once can cause filter effects to cascade to instances where they shouldn't be applied. This is because they all have the same underlying filter ID. 

Additionally, this renders the symbol in white when in dark mode. 

Fixes #618 
