### PR TITLE
`contributions` is not always present for /refresh endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Storybook: http://localhost:6006/ (if started using `--profile storybook`)
 
 - Remove all cache data from Redis:
 
-  `docker compose run cache redis-cli -h cache -a flow_docs FLUSHALL`
+  `docker compose exec cache redis-cli -h cache -a flow_docs FLUSHALL`
 
 - Ensure node_modules is up-to-date.
 

--- a/app/routes/action/refresh.tsx
+++ b/app/routes/action/refresh.tsx
@@ -16,7 +16,7 @@ export type Body = {
   commitSha?: string
   repo: string
   contentPaths: string
-  contributions: Contribution[]
+  contributions?: Contribution[]
 }
 
 export const commitShaKey = `meta:last-refresh-commit-sha`

--- a/app/utils/mixpanel.server.ts
+++ b/app/utils/mixpanel.server.ts
@@ -7,20 +7,31 @@ import { Body, Contribution } from "~/routes/action/refresh"
  * @param eventData Object containing merge event data
  */
 export const recordRefreshEventInMixpanel = (eventData: Body) => {
-  const mixpanelData = eventData.contributions.map(
+  const properties = {
+    token: process.env.MIXPANEL_DOCSITE_PROJECT_TOKEN,
+    commitCount: 0,
+    commitSha: eventData.commitSha,
+    repo: eventData.repo,
+    contentPaths: eventData.contentPaths,
+    keys: eventData.keys,
+  }
+
+  const mixpanelData = eventData.contributions?.map(
     (contribution: Contribution) => ({
       event: "Docs Refresh",
       properties: {
-        token: process.env.MIXPANEL_DOCSITE_PROJECT_TOKEN,
+        ...properties,
         distinct_id: contribution.contributor,
         commitCount: Number(contribution.commitCount),
-        commitSha: eventData.commitSha,
-        repo: eventData.repo,
-        contentPaths: eventData.contentPaths,
-        keys: eventData.keys,
       },
     })
-  )
+  ) || [
+    {
+      event: "Docs Refresh",
+      properties,
+    },
+  ]
+
   axios.post(process.env.MIXPANEL_EVENT_TRACKING_URL as string, mixpanelData, {
     headers: { Accept: "text/plain", "Content-Type": "application/json" },
   })


### PR DESCRIPTION
It looks like the error in #632 is actually caused by assuming the `contributions` property will be provided to the endpoint, which isn't happening. This guards for that. 