### PR TITLE
Cache paths that result in 404s for 30 days.

### DIFF
--- a/app/cms/cache.server.ts
+++ b/app/cms/cache.server.ts
@@ -185,11 +185,11 @@ async function cachified<
     fn: getFreshValue,
     timings,
   }).catch((error: unknown) => {
-    console.error(
-      `getting a fresh value failed`,
-      { cacheKey: key, fallbackToCache, forceFresh },
-      error
-    )
+    // console.error(
+    //   `getting a fresh value failed`,
+    //   { cacheKey: key, fallbackToCache, forceFresh },
+    //   error
+    // )
     // If we got this far without forceFresh then we know there's nothing
     // in the cache so no need to bother trying again without a forceFresh.
     // So we need both the option to fallback and the ability to fallback.


### PR DESCRIPTION
- Remove logs to clean up error reporting.
- Cache and lookup 404s to prevent GitHub fallback.
