### PR TITLE
Do not use full URL when determining docs canonical URLs

### DIFF
--- a/app/routes/__docs/$/$.tsx
+++ b/app/routes/__docs/$/$.tsx
@@ -83,7 +83,7 @@ export const loader = async ({ params, request }: LoaderArgs) => {
       page.frontmatter?.description || "Flow Developer Documentation"
 
     return json<LoaderData>({
-      links: [getCanonicalLinkDescriptor(request.url)],
+      links: [getCanonicalLinkDescriptor(path)],
       meta: getSocialMetas({
         title,
         description,


### PR DESCRIPTION
Use the extracted `path` and not the full `request.url` when setting the canonical URL for docs pages. 

When using TLS, it is terminated before it hits the app (load balancer or gateway), so from the application's perspective the request is just a plain `http` request. So for canonical URLs we shouldn't use `request.url` as-is because it may have the wrong protocol (or even origin, for that matter). Just passing the `path` we extracted will use the `ORIGIN` as a base and generate a URL based on the correct protocol/origin.