### PR TITLE
Ensure extension stripped from canonical URL

### DIFF
--- a/app/ui/design-system/src/lib/utils/stripExtension.ts
+++ b/app/ui/design-system/src/lib/utils/stripExtension.ts
@@ -1,1 +1,1 @@
-export const stripExtension = (href: string) => href.replace(/(.md|.mdx)/, "")
+export const stripExtension = (href: string) => href.replace(/(.mdx?)/, "")


### PR DESCRIPTION
The previous change used `path` directory from the `params` to determine the canonical URL, but that may include an extension which should be stripped. This ensures that extension is no longer included.

This also fixes an issue with the `stripExtension` regex which wasn't previously working correctly with `.mdx` extensions because it would catch the `.md` part of the expression first, leaving a single "x" behind. (i.e. "foo.mdx" would become "foox")