### PR TITLE
Handle links/meta when loader returns no data

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -78,7 +78,8 @@ export const links: LinksFunction = () => {
   ]
 }
 
-export const meta: MetaFunction = ({ data }: { data: LoaderData }) => data.meta
+export const meta: MetaFunction = ({ data }: { data: LoaderData }) =>
+  data?.meta || {}
 
 export type LoaderData = {
   algolia?: SearchProps

--- a/app/routes/__docs/$/$.tsx
+++ b/app/routes/__docs/$/$.tsx
@@ -28,9 +28,10 @@ import {
 
 export const handle: {
   dynamicLinks: DynamicLinksFunction<LoaderData>
-} = { dynamicLinks: ({ data }) => data.links }
+} = { dynamicLinks: ({ data }) => data?.links || [] }
 
-export const meta: MetaFunction = ({ data }: { data: LoaderData }) => data.meta
+export const meta: MetaFunction = ({ data }: { data: LoaderData }) =>
+  data?.meta || {}
 
 type LoaderData = {
   links: LinkDescriptor[]

--- a/app/routes/community.tsx
+++ b/app/routes/community.tsx
@@ -25,9 +25,10 @@ import { externalLinks } from "../data/external-links"
 
 export const handle: {
   dynamicLinks: DynamicLinksFunction<LoaderData>
-} = { dynamicLinks: ({ data }) => data.links }
+} = { dynamicLinks: ({ data }) => data?.links || [] }
 
-export const meta: MetaFunction = ({ data }: { data: LoaderData }) => data.meta
+export const meta: MetaFunction = ({ data }: { data: LoaderData }) =>
+  data?.meta || {}
 
 export type LoaderData = CommunityPageProps & {
   links: LinkDescriptor[]

--- a/app/routes/contact.tsx
+++ b/app/routes/contact.tsx
@@ -12,7 +12,7 @@ export const action = () => {
 
 export const handle: {
   dynamicLinks: DynamicLinksFunction<LoaderData>
-} = { dynamicLinks: ({ data }) => data.links }
+} = { dynamicLinks: ({ data }) => data?.links || [] }
 
 export type LoaderData = {
   links: LinkDescriptor[]

--- a/app/routes/getting-started.tsx
+++ b/app/routes/getting-started.tsx
@@ -30,9 +30,10 @@ import { externalLinks } from "../data/external-links"
 
 export const handle: {
   dynamicLinks: DynamicLinksFunction<LoaderData>
-} = { dynamicLinks: ({ data }) => data.links }
+} = { dynamicLinks: ({ data }) => data?.links || [] }
 
-export const meta: MetaFunction = ({ data }: { data: LoaderData }) => data.meta
+export const meta: MetaFunction = ({ data }: { data: LoaderData }) =>
+  data?.meta || {}
 
 export type LoaderData = Omit<
   GettingStartedPageProps,

--- a/app/routes/http-api.tsx
+++ b/app/routes/http-api.tsx
@@ -1,4 +1,9 @@
-import { HtmlMetaDescriptor, json, LinkDescriptor } from "@remix-run/node"
+import {
+  HtmlMetaDescriptor,
+  json,
+  LinkDescriptor,
+  MetaFunction,
+} from "@remix-run/node"
 import { RedocStandalone } from "redoc"
 import { ClientOnly, DynamicLinksFunction } from "remix-utils"
 import { Theme, useTheme } from "~/cms/utils/theme.provider"
@@ -6,7 +11,10 @@ import { getCanonicalLinkDescriptor } from "../utils/seo.server"
 
 export const handle: {
   dynamicLinks: DynamicLinksFunction<LoaderData>
-} = { dynamicLinks: ({ data }) => data.links }
+} = { dynamicLinks: ({ data }) => data?.links || [] }
+
+export const meta: MetaFunction = ({ data }: { data: LoaderData }) =>
+  data?.meta || {}
 
 export type LoaderData = {
   links: LinkDescriptor[]

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -23,6 +23,10 @@ import {
 } from "../data/tools"
 import { getCanonicalLinkDescriptor } from "../utils/seo.server"
 
+export const handle: {
+  dynamicLinks: DynamicLinksFunction<LoaderData>
+} = { dynamicLinks: ({ data }) => data?.links || [] }
+
 export type LoaderData = Omit<HomePageProps, "threeColumnItems"> & {
   links: LinkDescriptor[]
 }
@@ -59,10 +63,6 @@ export const loader = async () => {
     editPageUrl,
   })
 }
-
-export const handle: {
-  dynamicLinks: DynamicLinksFunction<LoaderData>
-} = { dynamicLinks: ({ data }) => data.links }
 
 export default function Index() {
   const data = useLoaderData<typeof loader>()

--- a/app/routes/learn.tsx
+++ b/app/routes/learn.tsx
@@ -22,9 +22,10 @@ import { externalLinks } from "../data/external-links"
 
 export const handle: {
   dynamicLinks: DynamicLinksFunction<LoaderData>
-} = { dynamicLinks: ({ data }) => data.links }
+} = { dynamicLinks: ({ data }) => data?.links || [] }
 
-export const meta: MetaFunction = ({ data }: { data: LoaderData }) => data.meta
+export const meta: MetaFunction = ({ data }: { data: LoaderData }) =>
+  data?.meta || {}
 
 export type LoaderData = Omit<LearnPageProps, "threeColumnItems"> & {
   links: LinkDescriptor[]

--- a/app/routes/network/$networkName.tsx
+++ b/app/routes/network/$networkName.tsx
@@ -19,9 +19,10 @@ import { networks } from "../../data/networks"
 
 export const handle: {
   dynamicLinks: DynamicLinksFunction<LoaderData>
-} = { dynamicLinks: ({ data }) => data.links }
+} = { dynamicLinks: ({ data }) => data?.links || [] }
 
-export const meta: MetaFunction = ({ data }: { data: LoaderData }) => data.meta
+export const meta: MetaFunction = ({ data }: { data: LoaderData }) =>
+  data?.meta || {}
 
 export type LoaderData = NetworkDetailPageProps & {
   links: LinkDescriptor[]

--- a/app/routes/network/index.tsx
+++ b/app/routes/network/index.tsx
@@ -19,9 +19,10 @@ import { networks } from "../../data/networks"
 
 export const handle: {
   dynamicLinks: DynamicLinksFunction<LoaderData>
-} = { dynamicLinks: ({ data }) => data.links }
+} = { dynamicLinks: ({ data }) => data?.links || [] }
 
-export const meta: MetaFunction = ({ data }: { data: LoaderData }) => data.meta
+export const meta: MetaFunction = ({ data }: { data: LoaderData }) =>
+  data?.meta || {}
 
 export type LoaderData = NetworkPageProps & {
   links: LinkDescriptor[]

--- a/app/routes/tools.tsx
+++ b/app/routes/tools.tsx
@@ -15,9 +15,10 @@ import ToolsPage, {
 
 export const handle: {
   dynamicLinks: DynamicLinksFunction<LoaderData>
-} = { dynamicLinks: ({ data }) => data.links }
+} = { dynamicLinks: ({ data }) => data?.links || [] }
 
-export const meta: MetaFunction = ({ data }: { data: LoaderData }) => data.meta
+export const meta: MetaFunction = ({ data }: { data: LoaderData }) =>
+  data?.meta || {}
 
 export type LoaderData = ToolsPageProps & {
   links: LinkDescriptor[]


### PR DESCRIPTION
Ensures that pages return 404s when appropriate. 

When an error occurred in a loader it could cause `data` to be undefined. But the `meta`  and `links` handlers are stilled called, so we need to take into account that value may be undefined.

Closes #650 