### PR TITLE
Preview docs from different branches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ apps/**/.cache
 .vscode
 
 node_modules
+package-lock.json
 
 /.cache
 /build

--- a/app/cms/github.server.ts
+++ b/app/cms/github.server.ts
@@ -269,7 +269,7 @@ function getCommits(repo: Repo, path: string, perPage?: number) {
   return octokit.rest.repos.listCommits({
     owner: repo.owner,
     repo: repo.name,
-    ref: repo.branch,
+    sha: repo.branch,
     path,
     per_page: perPage,
   })

--- a/app/data/doc-collections/index.ts
+++ b/app/data/doc-collections/index.ts
@@ -19,8 +19,6 @@ import nodes from "./nodes.json"
 import testing__mock_developer_doc_json_manifest_schema_error from "./testing__mock-developer-doc-json-manifest-schema-error.json"
 import testing__mock_developer_doc_json_valid from "./testing__mock-developer-doc-json-valid.json"
 import testing__mock_developer_doc_syntax_error from "./testing__mock-developer-doc-syntax-error.json"
-import testing__bar from "./testing__bar.json"
-import testing__foo from "./testing__foo.json"
 import tools__emulator from "./tools__emulator.json"
 import tools__fcl_dev_wallet from "./tools__fcl-dev-wallet.json"
 import tools__fcl_js from "./tools__fcl-js.json"
@@ -42,8 +40,6 @@ export const testCollections = {
     testing__mock_developer_doc_json_valid,
   "testing/mock_developer_doc_syntax_error":
     testing__mock_developer_doc_syntax_error,
-  "testing/bar": testing__bar,
-  "testing/foo": testing__foo,
 }
 
 export const docCollections = {

--- a/app/data/doc-collections/index.ts
+++ b/app/data/doc-collections/index.ts
@@ -19,6 +19,8 @@ import nodes from "./nodes.json"
 import testing__mock_developer_doc_json_manifest_schema_error from "./testing__mock-developer-doc-json-manifest-schema-error.json"
 import testing__mock_developer_doc_json_valid from "./testing__mock-developer-doc-json-valid.json"
 import testing__mock_developer_doc_syntax_error from "./testing__mock-developer-doc-syntax-error.json"
+import testing__bar from "./testing__bar.json"
+import testing__foo from "./testing__foo.json"
 import tools__emulator from "./tools__emulator.json"
 import tools__fcl_dev_wallet from "./tools__fcl-dev-wallet.json"
 import tools__fcl_js from "./tools__fcl-js.json"
@@ -40,6 +42,8 @@ export const testCollections = {
     testing__mock_developer_doc_json_valid,
   "testing/mock_developer_doc_syntax_error":
     testing__mock_developer_doc_syntax_error,
+  "testing/bar": testing__bar,
+  "testing/foo": testing__foo,
 }
 
 export const docCollections = {

--- a/app/routes/__docs/$.tsx
+++ b/app/routes/__docs/$.tsx
@@ -8,6 +8,7 @@ import {
   DocManifest,
   findDocCollection,
   findDocManifest,
+  RemoteRepoError,
 } from "../../cms/collections.server"
 import { stripTrailingSlashes } from "../../cms/utils/strip-slashes"
 import { SIDEBAR_DROPDOWN_MENU } from "../../data/sidebar-dropdown-menu"
@@ -15,28 +16,35 @@ import AppLink from "../../ui/design-system/src/lib/Components/AppLink"
 import { ErrorPage } from "../../ui/design-system/src/lib/Components/ErrorPage"
 import { InternalSidebarUrlContext } from "../../ui/design-system/src/lib/Components/InternalSidebar/InternalSidebarUrlContext"
 import { InternalPageContainer } from "../../ui/design-system/src/lib/Pages/InternalPage/InternalPageContainer"
+import { ENABLE_PREVIEWS } from "../../utils/env.server"
 
 type LoaderData = Pick<
   NonNullable<DocManifest & DocCollectionInfo>,
+  | "collectionRootPath"
+  | "displayName"
+  | "header"
   | "sidebar"
   | "sidebarRootPath"
-  | "displayName"
-  | "collectionRootPath"
-  | "header"
+  | "source"
 > & {
   sidebarDropdownMenu: typeof SIDEBAR_DROPDOWN_MENU
-  remoteRepoError?: string
+  remoteRepoError?: RemoteRepoError
+  preview?: string
 }
 
 export const loader = async ({ params, request }: LoaderArgs) => {
   const path = params["*"]
+
+  const url = new URL(request.url)
+  const preview =
+    (ENABLE_PREVIEWS && url.searchParams.get("preview")) || undefined
 
   if (path?.endsWith("/")) {
     // For consistency, strip trailing slashes from all URLs.
     return redirect(join("/", stripTrailingSlashes(path)), 302)
   }
 
-  if (path?.endsWith("md") || path?.endsWith("mdx")) {
+  if (path?.endsWith(".md") || path?.endsWith(".mdx")) {
     return redirect(join("/", removeMDorMDXFileExtension(path)), 302)
   }
 
@@ -49,7 +57,11 @@ export const loader = async ({ params, request }: LoaderArgs) => {
     throw json({ status: "noPage" }, { status: 404 })
   }
 
-  const docManifest = await findDocManifest(path, { request })
+  const docManifest = await findDocManifest(path, {
+    request,
+    ref: preview || undefined,
+    forceFresh: !!preview,
+  })
   invariant(docManifest, `expected manifest`)
 
   if (docManifest.redirect) {
@@ -65,42 +77,64 @@ export const loader = async ({ params, request }: LoaderArgs) => {
   }
 
   return json<LoaderData>({
-    sidebar: docManifest.sidebar,
-    sidebarRootPath: docManifest.sidebarRootPath,
-    displayName: docManifest.displayName,
     collectionRootPath: collection.collectionRootPath,
+    displayName: docManifest.displayName,
     header: docManifest.header,
+    preview,
+    remoteRepoError: docManifest.remoteRepoError,
+    sidebar: docManifest.sidebar,
     sidebarDropdownMenu: SIDEBAR_DROPDOWN_MENU,
-    remoteRepoError:
-      process.env.NODE_ENV === "development"
-        ? docManifest.remoteRepoError
-        : undefined,
+    sidebarRootPath: docManifest.sidebarRootPath,
+    source: docManifest.source,
   })
 }
 
 export default () => {
   const data = useLoaderData<typeof loader>()
+  const searchParams = data.preview ? { preview: data.preview } : undefined
 
   return (
     <InternalSidebarUrlContext.Provider
-      value={{ basePath: data.sidebarRootPath || data.collectionRootPath }}
+      value={{
+        basePath: data.sidebarRootPath || data.collectionRootPath,
+        searchParams,
+      }}
     >
-      <InternalPageContainer
-        additionalBreadrumbs={[
-          { href: "/flow", title: "Flow" },
-          { href: "/learn", title: "Learn" },
-          { href: "/nodes", title: "Nodes" },
-          { href: "/tools", title: "Tools" },
-        ]}
-        collectionDisplayName={data.displayName}
-        collectionRootPath={data.collectionRootPath}
-        header={data.header}
-        sidebarItems={data.sidebar}
-        sidebarDropdownMenu={data.sidebarDropdownMenu}
-        remoteRepoError={data.remoteRepoError}
-      >
-        <Outlet />
-      </InternalPageContainer>
+      {data.preview && (
+        <div className="fixed top-0 left-0 right-0 z-50 bg-rose-300 text-center text-sm dark:bg-rose-400 ">
+          Previewing:{" "}
+          <a
+            href={`https://github.com/${data.source.owner}/${data.source.name}/tree/${data.preview}`}
+            className="font-bold"
+          >
+            {data.preview}
+          </a>
+        </div>
+      )}
+      {data.remoteRepoError?.type === "RefNotFound" ? (
+        <ErrorPage
+          title="Preview not found"
+          subtitle="The preview requested could not be found"
+          actions={null}
+        />
+      ) : (
+        <InternalPageContainer
+          additionalBreadrumbs={[
+            { href: "/flow", title: "Flow" },
+            { href: "/learn", title: "Learn" },
+            { href: "/nodes", title: "Nodes" },
+            { href: "/tools", title: "Tools" },
+          ]}
+          collectionDisplayName={data.displayName}
+          collectionRootPath={data.collectionRootPath}
+          header={data.header}
+          sidebarItems={data.sidebar}
+          sidebarDropdownMenu={data.sidebarDropdownMenu}
+          remoteRepoError={data.remoteRepoError?.message}
+        >
+          <Outlet />
+        </InternalPageContainer>
+      )}
     </InternalSidebarUrlContext.Provider>
   )
 }

--- a/app/routes/__docs/$.tsx
+++ b/app/routes/__docs/$.tsx
@@ -83,7 +83,7 @@ export default () => {
 
   return (
     <InternalSidebarUrlContext.Provider
-      value={data.sidebarRootPath || data.collectionRootPath}
+      value={{ basePath: data.sidebarRootPath || data.collectionRootPath }}
     >
       <InternalPageContainer
         additionalBreadrumbs={[

--- a/app/routes/__docs/$.tsx
+++ b/app/routes/__docs/$.tsx
@@ -101,7 +101,7 @@ export default () => {
       }}
     >
       {data.preview && (
-        <div className="fixed top-0 left-0 right-0 z-50 bg-rose-300 text-center text-sm dark:bg-rose-400 ">
+        <div className="fixed top-0 left-0 right-0 z-50 bg-cyan-300 text-center text-sm dark:bg-cyan-600 ">
           Previewing:{" "}
           <a
             href={`https://github.com/${data.source.owner}/${data.source.name}/tree/${data.preview}`}

--- a/app/routes/__docs/$/$.tsx
+++ b/app/routes/__docs/$/$.tsx
@@ -113,7 +113,7 @@ export default () => {
   const MDXContent = useMdxComponent(page)
 
   return (
-    <InternalUrlContext.Provider value={resolvedPath}>
+    <InternalUrlContext.Provider value={{ basePath: resolvedPath }}>
       <InternalPageContent
         sidebarItems={sidebar}
         editPageUrl={page.origin.html_url || undefined}

--- a/app/routes/__docs/$/$.tsx
+++ b/app/routes/__docs/$/$.tsx
@@ -20,6 +20,7 @@ import AppLink from "../../../ui/design-system/src/lib/Components/AppLink"
 import { ErrorPage } from "../../../ui/design-system/src/lib/Components/ErrorPage"
 import { InternalUrlContext } from "../../../ui/design-system/src/lib/Components/InternalUrlContext"
 import { InternalPageContent } from "../../../ui/design-system/src/lib/Pages/InternalPage/InternalPageContent"
+import { ENABLE_PREVIEWS } from "../../../utils/env.server"
 import logger from "../../../utils/logging.server"
 import {
   getCanonicalLinkDescriptor,
@@ -37,6 +38,7 @@ type LoaderData = {
   links: LinkDescriptor[]
   meta: HtmlMetaDescriptor
   page: MdxPage
+  preview?: string
   resolvedPath: string
   sidebar: SidebarItemList | undefined
   url: string
@@ -45,12 +47,19 @@ type LoaderData = {
 export const loader = async ({ params, request }: LoaderArgs) => {
   let path = params["*"]
 
+  const url = new URL(request.url)
+  const preview =
+    (ENABLE_PREVIEWS && url.searchParams.get("preview")) || undefined
+
   if (!path) {
     throw json({ status: "noRepo" }, { status: 404 })
   }
 
   const data = findDocCollection(path)
-  const manifest = await findDocManifest(path, { request })
+  const manifest = await findDocManifest(path, {
+    request,
+    ref: preview || undefined,
+  })
 
   if (!data || !manifest) {
     throw json({ status: "noRepo" }, { status: 404 })
@@ -59,10 +68,13 @@ export const loader = async ({ params, request }: LoaderArgs) => {
   try {
     const page = await getMdxPage(
       {
-        source: data.source,
+        source: {
+          ...data.source,
+          branch: preview || data.source.branch,
+        },
         path: data.contentPath,
       },
-      { request, forceFresh: process.env.FORCE_REFRESH === "true" }
+      { request, forceFresh: process.env.FORCE_REFRESH === "true" || !!preview }
     )
 
     if (!page) {
@@ -84,7 +96,7 @@ export const loader = async ({ params, request }: LoaderArgs) => {
       page.frontmatter?.description || "Flow Developer Documentation"
 
     return json<LoaderData>({
-      links: [getCanonicalLinkDescriptor(resolvedPath)],
+      links: preview ? [] : [getCanonicalLinkDescriptor(resolvedPath)],
       meta: getSocialMetas({
         title,
         description,
@@ -95,6 +107,7 @@ export const loader = async ({ params, request }: LoaderArgs) => {
       resolvedPath,
       sidebar: manifest.sidebar,
       url: request.url,
+      preview,
     })
   } catch (e) {
     if (e instanceof NotFoundError) {
@@ -108,12 +121,16 @@ export const loader = async ({ params, request }: LoaderArgs) => {
 }
 
 export default () => {
-  const { sidebar, page, resolvedPath } = useLoaderData<typeof loader>()
+  const { sidebar, page, resolvedPath, preview } =
+    useLoaderData<typeof loader>()
+  const searchParams = preview ? { preview } : undefined
 
   const MDXContent = useMdxComponent(page)
 
   return (
-    <InternalUrlContext.Provider value={{ basePath: resolvedPath }}>
+    <InternalUrlContext.Provider
+      value={{ basePath: resolvedPath, searchParams }}
+    >
       <InternalPageContent
         sidebarItems={sidebar}
         editPageUrl={page.origin.html_url || undefined}

--- a/app/routes/__docs/assets.$.ts
+++ b/app/routes/__docs/assets.$.ts
@@ -4,8 +4,9 @@ import mime from "mime-types"
 import { downloadFileByPath } from "~/cms"
 import { findDocCollection } from "../../cms/collections.server"
 import { NotFoundError } from "../../cms/errors/not-found-error"
+import { ENABLE_PREVIEWS } from "../../utils/env.server"
 
-export const loader = async ({ params }: LoaderArgs) => {
+export const loader = async ({ params, request }: LoaderArgs) => {
   const path = params["*"]
 
   if (!path) {
@@ -21,10 +22,17 @@ export const loader = async ({ params }: LoaderArgs) => {
     })
   }
 
+  const url = new URL(request.url)
+  const preview =
+    (ENABLE_PREVIEWS && url.searchParams.get("preview")) || undefined
+
   try {
     // TODO: cache this!
     const buffer = await downloadFileByPath(
-      contentSpec.source,
+      {
+        ...contentSpec.source,
+        branch: preview || contentSpec.source.branch,
+      },
       contentSpec.contentPath
     )
 

--- a/app/routes/robots[.]txt.ts
+++ b/app/routes/robots[.]txt.ts
@@ -9,6 +9,8 @@ User-agent: *
 Sitemap: ${sitemapUrl}
 Disallow: /_meta
 Disallow: /action
+Disallow: /*?preview=*
+Disallow: /*&preview=*
 `
 
   if (process.env.NODE_ENV !== "production") {
@@ -16,7 +18,10 @@ Disallow: /action
 
 User-agent: Algolia Crawler
 Sitemap: ${sitemapUrl}
-Allow: /
+Disallow: /_meta
+Disallow: /action
+Disallow: /*?preview=*
+Disallow: /*&preview=*
 
 User-agent: *
 Disallow: /

--- a/app/ui/design-system/src/lib/Components/InternalSidebar/InternalSidebarUrlContext.ts
+++ b/app/ui/design-system/src/lib/Components/InternalSidebar/InternalSidebarUrlContext.ts
@@ -1,3 +1,6 @@
 import { createContext } from "react"
+import { InternalUrlContextValue } from "../InternalUrlContext"
 
-export const InternalSidebarUrlContext = createContext<string>("undefined")
+export const InternalSidebarUrlContext = createContext<InternalUrlContextValue>(
+  {}
+)

--- a/app/ui/design-system/src/lib/Components/InternalSidebar/useActiveSidebarItems.ts
+++ b/app/ui/design-system/src/lib/Components/InternalSidebar/useActiveSidebarItems.ts
@@ -3,6 +3,7 @@ import { useContext } from "react"
 import { isSidebarLinkItem, SidebarItem, SidebarLinkItem } from "."
 import { stripTrailingSlashes } from "../../utils/stripTrailingSlashes"
 import { titleFromHref } from "../../utils/titleFromHref"
+import { resolveUrl } from "../../utils/useResolvedUrl"
 import { InternalSidebarUrlContext } from "./InternalSidebarUrlContext"
 
 /**
@@ -18,17 +19,20 @@ export const flattenItems = (items?: SidebarItem[]): SidebarItem[] =>
 export const useActiveSidebarItems = (items: SidebarItem[]) => {
   const location = useLocation()
   const path = stripTrailingSlashes(location.pathname)
-  const sidebarBasePath = useContext(InternalSidebarUrlContext)
+  const { basePath, searchParams } = useContext(InternalSidebarUrlContext)
 
   const linkItems =
     flattenItems(items).filter<SidebarLinkItem>(isSidebarLinkItem)
 
   const resolvedLinkItems = linkItems.map((item) => ({
-    href: stripTrailingSlashes(`${sidebarBasePath}${item.href}`),
+    href: resolveUrl(item.href, basePath, { searchParams }),
+    path: stripTrailingSlashes(`${basePath}${item.href}`),
     title: item.title || titleFromHref(item.href),
   }))
 
-  const activeIndex = resolvedLinkItems.findIndex(({ href }) => href === path)
+  const activeIndex = resolvedLinkItems.findIndex(
+    (resolved) => resolved.path === path
+  )
 
   return {
     previous: activeIndex > 0 ? resolvedLinkItems[activeIndex - 1] : undefined,

--- a/app/ui/design-system/src/lib/Components/InternalSidebar/useResolvedSidebarUrl.ts
+++ b/app/ui/design-system/src/lib/Components/InternalSidebar/useResolvedSidebarUrl.ts
@@ -3,6 +3,9 @@ import { useResolvedUrl } from "../../utils/useResolvedUrl"
 import { InternalSidebarUrlContext } from "./InternalSidebarUrlContext"
 
 export const useResolvedSidebarUrl = (href: string) => {
-  const basePath = useContext(InternalSidebarUrlContext)
-  return useResolvedUrl(href, basePath, { stripTrailingSlash: true })
+  const { basePath, searchParams } = useContext(InternalSidebarUrlContext)
+  return useResolvedUrl(href, basePath, {
+    stripTrailingSlash: true,
+    searchParams,
+  })
 }

--- a/app/ui/design-system/src/lib/Components/InternalUrlContext.ts
+++ b/app/ui/design-system/src/lib/Components/InternalUrlContext.ts
@@ -1,27 +1,30 @@
 import { createContext, useContext } from "react"
+import { stripLeadingSlashes } from "../utils/stripLeadingSlashes"
 import { useResolvedUrl } from "../utils/useResolvedUrl"
+
+export type InternalUrlContextValue = {
+  basePath?: string
+  searchParams?: Record<string, string>
+}
 
 /**
  * Tracks the "base URL" to use for relative links found in "internal" content.
  */
-export const InternalUrlContext = createContext("/")
+export const InternalUrlContext = createContext<InternalUrlContextValue>({})
 
 /**
  * Resolves any relative internal URL to use the correct base path.
  */
 export const useInternalUrl = (href: string) => {
-  const basePath = useContext(InternalUrlContext)
-
-  return useResolvedUrl(href, basePath)
+  const { basePath, searchParams } = useContext(InternalUrlContext)
+  return useResolvedUrl(href, basePath, { searchParams })
 }
 
 /**
  * Resolves any relative asset URL by prepending the assets path.
  */
 export const useInternalAssetUrl = (href: string) => {
-  const basePath = useContext(InternalUrlContext)
-  return useResolvedUrl(
-    href,
-    `/assets${basePath.startsWith("/") ? "" : "/"}${basePath}`
-  )
+  const { basePath = "", searchParams } = useContext(InternalUrlContext)
+  const assetsBasePath = "/assets/" + stripLeadingSlashes(basePath)
+  return useResolvedUrl(href, assetsBasePath, { searchParams })
 }

--- a/app/ui/design-system/src/lib/utils/stripLeadingSlashes.ts
+++ b/app/ui/design-system/src/lib/utils/stripLeadingSlashes.ts
@@ -1,0 +1,1 @@
+export const stripLeadingSlashes = (input: string) => input.replace(/^\/+/, "")

--- a/app/utils/env.server.ts
+++ b/app/utils/env.server.ts
@@ -14,6 +14,8 @@ export function getEnv() {
   }
 }
 
+export const ENABLE_PREVIEWS = process.env.ENABLE_PREVIEWS === "true"
+
 export type ENV = ReturnType<typeof getEnv>
 
 function getFallbackOrigin() {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ x-app-defaults: &app-defaults
   volumes:
     - .:/opt/next-docs
     - ./package.json:/opt/next-docs/package.json
-    - ./package-lock.json:/opt/next-docs/package-lock.json
+    - ./yarn.lock:/opt/next-docs/yarn.lock
     - node_modules:/opt/next-docs/node_modules
 
 services:

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "colorette": "^2.0.19",
     "date-fns": "^2.28.0",
     "discord.js": "^12",
+    "errorish": "^1.0.0",
     "file-type": "^17.1.6",
     "github-slugger": "^1.4.0",
     "hast-util-to-string": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8552,6 +8552,13 @@ error-stack-parser@^2.0.6:
   dependencies:
     stackframe "^1.3.4"
 
+errorish@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/errorish/-/errorish-1.0.0.tgz#37fe8113466f29d64d15c742ac9d54d1da120f3e"
+  integrity sha512-L02wV8ZV1ANodb8lyWOPSabE+Ogo1vP7zw9un0VRM8KdwvYF4sHI/7TliaUNC+FQUxxphcYHITeEo1MGcfE7LQ==
+  dependencies:
+    type-core "^0.6.0"
+
 es-abstract@^1.19.0, es-abstract@^1.19.1, es-abstract@^1.19.2, es-abstract@^1.19.5, es-abstract@^1.20.0, es-abstract@^1.20.1:
   version "1.20.1"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.20.1.tgz#027292cd6ef44bd12b1913b828116f54787d1814"
@@ -17862,6 +17869,11 @@ type-check@~0.3.2:
   integrity sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
   dependencies:
     prelude-ls "~1.1.2"
+
+type-core@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/type-core/-/type-core-0.6.0.tgz#3b830c7925798995786edb5f29896da91c45f3b1"
+  integrity sha512-2Wr5qtj4Vl3ZD3JaXheLz4BL+mXxuV9CjvuPl8dkqB/72FdvnuvkTp+WoGXDg9SpRlx1MkuTg7YgVXZSsrHuSw==
 
 type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5:
   version "4.0.8"


### PR DESCRIPTION
Closes #654 

This allows specifying a `preview=` query string parameter which takes a ref or branch name and will fetch docs from that branch/ref instead of the one specified by the doc collection manifest.

It looks something like this:

<img width="1217" alt="Screen Shot 2022-09-16 at 11 40 25 AM" src="https://user-images.githubusercontent.com/393220/190679698-c75b4986-3d2f-477b-a063-c1f5398ee3bb.png">

All relative URLs within that document collection also include the `preview=` parameter: sidebar links, "internal" doc links, next/previous links, asset URLs. 

If the branch does not exist and error indicates that:
 
<img width="1221" alt="Screen Shot 2022-09-16 at 11 40 34 AM" src="https://user-images.githubusercontent.com/393220/190679940-8cd049cd-0c64-4188-817d-b932ce731f5f.png">
