### PR TITLE
Adjust header text on document previews

### DIFF
--- a/app/routes/__docs/$.tsx
+++ b/app/routes/__docs/$.tsx
@@ -102,12 +102,12 @@ export default () => {
     >
       {data.preview && (
         <div className="fixed top-0 left-0 right-0 z-50 bg-cyan-300 text-center text-sm dark:bg-cyan-600 ">
-          Previewing:{" "}
+          You are viewing an unpublished preview.
           <a
             href={`https://github.com/${data.source.owner}/${data.source.name}/tree/${data.preview}`}
             className="font-bold"
           >
-            {data.preview}
+            View branch in GitHub.
           </a>
         </div>
       )}


### PR DESCRIPTION
This just updates the header text for previews to:

> You are viewing an unpublished preview. View branch in GitHub.

I thought I got this in with the other PR but it looks like it never got pushed from my local changes. 