### PR TITLE
Invalidate cache keys used in directory listing

### DIFF
--- a/app/cms/doc-collections/cache-keys.server.ts
+++ b/app/cms/doc-collections/cache-keys.server.ts
@@ -1,4 +1,5 @@
 import type { DocCollectionSource } from "~/cms/doc-collections/types"
+import { FetchDirectoryContentOptions } from "../github/fetch-directory-content"
 
 export const documentCompiledKey = (
   source: DocCollectionSource,
@@ -11,3 +12,11 @@ export const documentDownloadKey = (
   fileOrDirPath: string
 ) =>
   `${source.owner}:${source.name}:${source.branch}:${source.rootPath}:${fileOrDirPath}:downloaded`
+
+export const directoryListKey = ({
+  owner,
+  repo,
+  ref,
+  path,
+}: FetchDirectoryContentOptions) =>
+  `github-dir-list:${owner}:${repo}:${ref}:${path}`

--- a/app/cms/github-webhook.server.test.ts
+++ b/app/cms/github-webhook.server.test.ts
@@ -1,6 +1,6 @@
 import {
-  pushEventCacheKeysToInvalidate,
   getDocumentPathsForPR,
+  pushEventCacheKeysToInvalidate,
 } from "./github-webhook.server"
 
 let exampleEvent: any = {
@@ -53,7 +53,7 @@ test("it returns document cache keys when document are modified", () => {
 
   const result = pushEventCacheKeysToInvalidate(event)
 
-  const keyPrefix = [
+  const docCollectionKey = [
     `onflow`,
     `mock-developer-doc`,
     `json-manifest-valid`,
@@ -62,10 +62,11 @@ test("it returns document cache keys when document are modified", () => {
 
   expect(result.cacheKeysToInvalidate).toEqual(
     new Set([
-      `${keyPrefix}:faq:compiled`,
-      `${keyPrefix}:faq:downloaded`,
-      `${keyPrefix}:foobar:compiled`,
-      `${keyPrefix}:foobar:downloaded`,
+      `github-dir-list:${docCollectionKey}`,
+      `${docCollectionKey}:faq:compiled`,
+      `${docCollectionKey}:faq:downloaded`,
+      `${docCollectionKey}:foobar:compiled`,
+      `${docCollectionKey}:foobar:downloaded`,
     ])
   )
 })
@@ -83,7 +84,7 @@ test("it returns special paths for index documents", () => {
   }
 
   const result = pushEventCacheKeysToInvalidate(event)
-  const keyPrefix = [
+  const docCollectionKey = [
     `onflow`,
     `mock-developer-doc`,
     `json-manifest-valid`,
@@ -92,14 +93,15 @@ test("it returns special paths for index documents", () => {
 
   expect(result.cacheKeysToInvalidate).toEqual(
     new Set([
-      `${keyPrefix}:index:compiled`,
-      `${keyPrefix}:index:downloaded`,
-      `${keyPrefix}::compiled`,
-      `${keyPrefix}::downloaded`,
-      `${keyPrefix}:foo/index:compiled`,
-      `${keyPrefix}:foo/index:downloaded`,
-      `${keyPrefix}:foo:compiled`,
-      `${keyPrefix}:foo:downloaded`,
+      `github-dir-list:${docCollectionKey}`,
+      `${docCollectionKey}:index:compiled`,
+      `${docCollectionKey}:index:downloaded`,
+      `${docCollectionKey}::compiled`,
+      `${docCollectionKey}::downloaded`,
+      `${docCollectionKey}:foo/index:compiled`,
+      `${docCollectionKey}:foo/index:downloaded`,
+      `${docCollectionKey}:foo:compiled`,
+      `${docCollectionKey}:foo:downloaded`,
     ])
   )
 })
@@ -124,17 +126,18 @@ test("it returns keys for the onflow repoo", () => {
   }
 
   const result = pushEventCacheKeysToInvalidate(event)
-  const keyPrefix = `onflow:flow:master:docs/content/dapp-development/`
+  const docCollectionKey = `onflow:flow:master:docs/content/dapp-development/`
 
   expect(result.docCollectionStatus).toBe("match")
   expect(result.cacheKeysToInvalidate).toEqual(
     new Set([
-      `${keyPrefix}::compiled`,
-      `${keyPrefix}::downloaded`,
-      `${keyPrefix}:index:compiled`,
-      `${keyPrefix}:index:downloaded`,
-      `${keyPrefix}:in-dapp-payments:compiled`,
-      `${keyPrefix}:in-dapp-payments:downloaded`,
+      `${docCollectionKey}::compiled`,
+      `${docCollectionKey}::downloaded`,
+      `${docCollectionKey}:index:compiled`,
+      `${docCollectionKey}:index:downloaded`,
+      `${docCollectionKey}:in-dapp-payments:compiled`,
+      `${docCollectionKey}:in-dapp-payments:downloaded`,
+      `github-dir-list:${docCollectionKey}`,
     ])
   )
 })

--- a/app/cms/github-webhook.server.test.ts
+++ b/app/cms/github-webhook.server.test.ts
@@ -62,7 +62,7 @@ test("it returns document cache keys when document are modified", () => {
 
   expect(result.cacheKeysToInvalidate).toEqual(
     new Set([
-      `github-dir-list:${docCollectionKey}`,
+      `github-dir-list:onflow:mock-developer-doc:json-manifest-valid:/docs`,
       `${docCollectionKey}:faq:compiled`,
       `${docCollectionKey}:faq:downloaded`,
       `${docCollectionKey}:foobar:compiled`,
@@ -93,7 +93,8 @@ test("it returns special paths for index documents", () => {
 
   expect(result.cacheKeysToInvalidate).toEqual(
     new Set([
-      `github-dir-list:${docCollectionKey}`,
+      `github-dir-list:onflow:mock-developer-doc:json-manifest-valid:/docs`,
+      `github-dir-list:onflow:mock-developer-doc:json-manifest-valid:/docs/foo`,
       `${docCollectionKey}:index:compiled`,
       `${docCollectionKey}:index:downloaded`,
       `${docCollectionKey}::compiled`,
@@ -137,7 +138,7 @@ test("it returns keys for the onflow repoo", () => {
       `${docCollectionKey}:index:downloaded`,
       `${docCollectionKey}:in-dapp-payments:compiled`,
       `${docCollectionKey}:in-dapp-payments:downloaded`,
-      `github-dir-list:${docCollectionKey}`,
+      `github-dir-list:onflow:flow:master:/docs/content/dapp-development`,
     ])
   )
 })

--- a/app/cms/github-webhook.server.ts
+++ b/app/cms/github-webhook.server.ts
@@ -131,6 +131,15 @@ export function pushEventCacheKeysToInvalidate(
         })
       )
 
+      keysToInvalidate.add(
+        directoryListKey({
+          owner: docCollection.source.owner,
+          repo: docCollection.source.name,
+          ref: docCollection.source.branch,
+          path: posix.dirname(path),
+        })
+      )
+
       let isIndex = path.endsWith("index.md") || path.endsWith("index.mdx")
       let urlPath = path.slice(docCollection.source.rootPath.length)
 

--- a/app/cms/github-webhook.server.ts
+++ b/app/cms/github-webhook.server.ts
@@ -9,6 +9,7 @@ import {
   documentDownloadKey,
 } from "./doc-collections/cache-keys.server"
 import { JSON_MANIFEST_FILENAME } from "./doc-collections/constants"
+import { stripSlahes } from "./utils/strip-slashes"
 
 type ProcessResult = {
   docCollectionStatus: "match" | "not-found"
@@ -127,7 +128,7 @@ export function pushEventCacheKeysToInvalidate(
           owner: docCollection.source.owner,
           repo: docCollection.source.name,
           ref: docCollection.source.branch,
-          path: docCollection.source.rootPath,
+          path: posix.resolve("/", stripSlahes(docCollection.source.rootPath)),
         })
       )
 
@@ -136,7 +137,7 @@ export function pushEventCacheKeysToInvalidate(
           owner: docCollection.source.owner,
           repo: docCollection.source.name,
           ref: docCollection.source.branch,
-          path: posix.dirname(path),
+          path: posix.resolve("/", posix.dirname(path)),
         })
       )
 

--- a/app/cms/github-webhook.server.ts
+++ b/app/cms/github-webhook.server.ts
@@ -1,13 +1,14 @@
-import { PushEvent, Commit } from "@octokit/webhooks-types"
+import { Commit, PushEvent } from "@octokit/webhooks-types"
 import { posix } from "node:path"
 import invariant from "tiny-invariant"
-import { JSON_MANIFEST_FILENAME } from "./doc-collections/constants"
 import { getManifestCacheKey } from "~/cms/doc-collections/get-manifest-cache-key"
 import { docCollections } from "~/data/doc-collections"
 import {
+  directoryListKey,
   documentCompiledKey,
   documentDownloadKey,
 } from "./doc-collections/cache-keys.server"
+import { JSON_MANIFEST_FILENAME } from "./doc-collections/constants"
 
 type ProcessResult = {
   docCollectionStatus: "match" | "not-found"
@@ -121,6 +122,15 @@ export function pushEventCacheKeysToInvalidate(
     )
 
     for (let path of documentPaths) {
+      keysToInvalidate.add(
+        directoryListKey({
+          owner: docCollection.source.owner,
+          repo: docCollection.source.name,
+          ref: docCollection.source.branch,
+          path: docCollection.source.rootPath,
+        })
+      )
+
       let isIndex = path.endsWith("index.md") || path.endsWith("index.mdx")
       let urlPath = path.slice(docCollection.source.rootPath.length)
 

--- a/app/cms/github/fetch-directory-content.ts
+++ b/app/cms/github/fetch-directory-content.ts
@@ -1,6 +1,7 @@
-import { octokit } from "./octokit.server"
 import { cachified } from "../cache.server"
+import { directoryListKey } from "../doc-collections/cache-keys.server"
 import { redisCache } from "../redis.server"
+import { octokit } from "./octokit.server"
 
 export type FetchDirectoryContentOptions = {
   owner: string
@@ -24,7 +25,7 @@ export const fetchDirectoryContent = async ({
     // a refresh it doesn't always refresh every single entry.
     maxAge: 1000 * 60 * 60 * 24 + Math.random() * 1000 * 60,
     forceFresh: process.env.FORCE_REFRESH === "true",
-    key: `github-dir-list:${owner}:${repo}:${ref}:${path}`,
+    key: directoryListKey({ owner, repo, ref, path }),
     getFreshValue: async () => {
       const { data } = await octokit.repos.getContent({
         owner,


### PR DESCRIPTION
keys begining with github-dir-list:*, e.g.

		127.0.0.1:6379> keys github*
		1) "github-dir-list:onflow:flow:master:/docs/content/kitty-items"
		2) "github-dir-list:onflow:cadence:master:/docs/language"
		3) "github-dir-list:onflow:flow-go-sdk:master:/docs"
		4) "github-dir-list:onflow:fcl-js:master:/docs"
		5) "github-dir-list:onflow:flow:master:/docs/content/concepts"
		6) "github-dir-list:onflow:fcl-js:master:/docs/reference"

were added to support document previews (as far as I understand) but
were not being invalidated, resulting in stale content across a few
repos and possibly being an explanation for #703

after merging, recommend deleting all redis keys prefixed with `github-dir-list:`
