### PR TITLE
Check external links during content check

### DIFF
--- a/app/@types/link-check.d.ts
+++ b/app/@types/link-check.d.ts
@@ -1,0 +1,101 @@
+// NPM: https://www.npmjs.com/package/link-check
+// Source: https://github.com/tcort/link-check
+
+declare module "link-check" {
+  export class LinkCheckResult {
+    /**
+     *  the link provided as input
+     */
+    link: string
+
+    /**
+     *  a string set to either alive or dead.
+     */
+    status: "alive" | "dead"
+
+    /**
+     *  the HTTP status code. Set to 0 if no HTTP status code was returned (e.g. when the server is down).
+     */
+    statusCode: number
+
+    /**
+     *  any connection error that occurred, otherwise null.
+     */
+    err: unknown
+  }
+
+  interface LinkCheckOptions {
+    /**
+     * array of anchor strings (e.g. [ "#foo", "#bar" ]) for checking anchor links (e.g. <a href="#foo">Foo</a>).
+     * @defaultValue `[]`
+     */
+    anchors?: string[]
+
+    /**
+     * the base URL for relative links.
+     */
+    baseUrl?: string
+
+    /**
+     *  timeout in zeit/ms format. (e.g. "2000ms", 20s, 1m). Default 10s.
+     * @defaultValue `"10s"`
+     */
+    timeout?: string
+
+    /**
+     * @experimental Undocumented
+     * @defaultValue `"10s"`
+     */
+    open_timeout?: string
+
+    /**
+     * the user-agent string. Default ${name}/${version} (e.g. link-check/4.5.5)
+     * @defaultValue `"link-check/5.2.0"`
+     */
+    user_agent?: string
+
+    /**
+     * an array of numeric HTTP Response codes which indicate that the link is alive. Entries in this array may also be regular expressions. Example: [ 200, /^[45][0-9]{2}$/ ]. Default [ 200 ].
+     * @defaultValue `[ 200 ]`
+     */
+    aliveStatusCodes?: Array<number | RegExp>
+
+    /**
+     * a string based attribute value object to send custom HTTP headers. Example: { 'Authorization' : 'Basic Zm9vOmJhcg==' }.
+     */
+    headers?: Record<string, string>
+
+    /**
+     * a boolean indicating whether to retry on a 429 (Too Many Requests) response. When true, if the response has a 429 HTTP code and includes an optional retry-after header, a retry will be attempted after the delay indicated in the retry-after header. If no retry-after header is present in the response or the retry-after header value is not valid according to RFC7231 (value must be in seconds), a default retry delay of 60 seconds will apply. This default can be overriden by the fallbackRetryDelay parameter.
+     * @defaultValue `false`
+
+     */
+    retryOn429?: boolean
+
+    /**
+     * the number of retries to be made on a 429 response. Default 2.
+     * @defaultValue `2`
+     */
+    retryCount?: number
+
+    /**
+     * the delay in zeit/ms format. (e.g. "2000ms", 20s, 1m) for retries on a 429 response when no retry-after header is returned or when it has an invalid value. Default is 60s.
+     * @defaultValue `"60s"`
+     */
+    fallbackRetryDelay?: string
+  }
+
+  interface LinkCheckCallback {
+    (err: null, result: LinkCheckResult): void
+    (err: Error, result: null): void
+  }
+
+  function linkCheck(
+    url: string,
+    opts: LinkCheckOptions,
+    cb: LinkCheckCallback
+  ): void
+  function linkCheck(url: string, cb: LinkCheckCallback): void
+
+  export default linkCheck
+}

--- a/app/cms/doc-validation/validate-link-external.ts
+++ b/app/cms/doc-validation/validate-link-external.ts
@@ -1,0 +1,79 @@
+import { ensure } from "errorish"
+import linkCheck, { LinkCheckResult } from "link-check"
+import { LinkItem } from "../rehype-plugins/extractLinks"
+import { ValidatedLink, ValidateLinkContext } from "./validate-link"
+
+/**
+ * An array of RegExp's to match against a URL's hostname
+ * that indicates we should ignore the URL and not test it's response.
+ */
+const IGNORED_HOSTNAMES = [/^(.+\.)?localhost/, /^(.+\.)?example.com/]
+
+const shouldIgnore = (href: string) => {
+  try {
+    const { hostname } = new URL(href)
+    return IGNORED_HOSTNAMES.some((regex) => regex.test(hostname))
+  } catch (_) {
+    // Should we return true so we don't make an unnecessary request?
+  }
+
+  return false
+}
+
+export const validateLinkExternal = async (
+  item: LinkItem,
+  _: ValidateLinkContext
+): Promise<ValidatedLink> => {
+  const { href } = item
+
+  if (shouldIgnore(href)) {
+    return {
+      ...item,
+      type: "external",
+      result: "ignored",
+      hint: "Links with this hostname are not checked",
+    }
+  }
+
+  try {
+    const result = await new Promise<LinkCheckResult>((resolve, reject) => {
+      linkCheck(
+        href,
+        {
+          aliveStatusCodes: [/^2\d\d$/],
+          user_agent: "FlowLinkChecker/1.0",
+          retryOn429: true,
+          fallbackRetryDelay: "20s",
+        },
+        (linkCheckErr, linkCheckResult) => {
+          if (linkCheckResult !== null) {
+            return resolve(linkCheckResult)
+          }
+          reject(linkCheckErr)
+        }
+      )
+    })
+
+    if (result.status === "alive") {
+      return {
+        ...item,
+        type: "external",
+        result: "ok",
+      }
+    }
+
+    return {
+      ...item,
+      type: "external",
+      result: result.statusCode === 404 ? "invalid" : "warning",
+      hint: `Link returned status ${result.statusCode} ${result.err || ""}`,
+    }
+  } catch (error) {
+    return {
+      ...item,
+      type: "external",
+      result: "invalid",
+      hint: `Checking link failed with error: ${ensure(error).message}`,
+    }
+  }
+}

--- a/app/cms/doc-validation/validate-link-internal.ts
+++ b/app/cms/doc-validation/validate-link-internal.ts
@@ -1,0 +1,67 @@
+import { posix } from "node:path"
+import { stripMarkdownExtension } from "../../ui/design-system/src/lib/utils/stripMarkdownExtension"
+import { LinkItem } from "../rehype-plugins/extractLinks"
+import { stripSlahes } from "../utils/strip-slashes"
+import { ValidatedLink, ValidateLinkContext } from "./validate-link"
+
+const PLACEHOLDER_ORIGIN = "https://example.com"
+
+export const normalizeRelativeUrl = (path: string) =>
+  stripSlahes(stripMarkdownExtension(path.toLowerCase()))
+
+export const validateLinkInternal = async (
+  item: LinkItem,
+  context: ValidateLinkContext
+): Promise<ValidatedLink> => {
+  const { href } = item
+
+  const { rootRelativePath, validRelativeFileUrls } = context
+
+  // This ensures we strip out any query strings or hashes (we can
+  // verify hashes another time)
+  const { pathname } = new URL(href, PLACEHOLDER_ORIGIN)
+
+  // resolve the path relative to the file's root path, but excluding
+  // the source's root path (which we cannot "break out" of)
+  const resolved = posix.resolve("/", rootRelativePath, pathname)
+  const normalizedHref = normalizeRelativeUrl(resolved)
+
+  return {
+    ...item,
+    type: "internal",
+    result: validRelativeFileUrls.includes(normalizedHref) ? "ok" : "invalid",
+    hint: getInternalLinkHint(item, { ...context, normalizedHref }),
+  }
+}
+
+type GetInternalLinkHintContext = ValidateLinkContext & {
+  normalizedHref: string
+}
+
+/**
+ * Tries to make an educated guess about what the user was trying to link to and/or offer some additional guidance about how to correct the link.
+ */
+function getInternalLinkHint(
+  { href }: LinkItem,
+  {
+    validRelativeFileUrls,
+    collection,
+    normalizedHref,
+  }: GetInternalLinkHintContext
+): string | undefined {
+  const possibleUrl = validRelativeFileUrls.find((url) =>
+    normalizedHref.includes(url)
+  )
+
+  if (possibleUrl) {
+    return `Did you mean \`${possibleUrl}\`?`
+  }
+
+  if (href.startsWith("/")) {
+    const { rootPath } = collection.source
+    const strippedHref = stripSlahes(href)
+    return `This looks like an absolute path. If you are linking to a relative file in the same doc collection (within \`${rootPath}\`) then you should use a relative path (Maybe you meant \`${strippedHref}\`?). If you're referencing a link external to this doc collection (outside of \`${rootPath}\`) you should use an absolute URL (Maybe you meant \`https://developers.flow.com/${strippedHref}\`?)`
+  }
+
+  return undefined
+}

--- a/app/cms/doc-validation/validate-link.ts
+++ b/app/cms/doc-validation/validate-link.ts
@@ -1,0 +1,92 @@
+import { isLinkExternal } from "~/ui/design-system/src/lib/utils/isLinkExternal"
+import { DocCollection } from "../doc-collections/types"
+import { LinkItem } from "../rehype-plugins/extractLinks"
+import { validateLinkExternal } from "./validate-link-external"
+import { validateLinkInternal } from "./validate-link-internal"
+
+export type ValidatedLinkType =
+  | "external"
+  | "internal"
+  | "mailto"
+  | "hash"
+  | "unknown"
+
+export type ValidatedLinkStatusFailure = "invalid"
+export type ValidatedLinkStatusWarning = "warning" | "unknown"
+export type ValidatedLinkStatusSuccess = "ok" | "ignored"
+
+export type ValidatedLinkStatus =
+  | ValidatedLinkStatusFailure
+  | ValidatedLinkStatusWarning
+  | ValidatedLinkStatusSuccess
+
+export interface ValidatedLink extends LinkItem {
+  type: ValidatedLinkType
+  hint?: string
+  result: ValidatedLinkStatus
+}
+
+export interface ValidatedLinkFailure extends ValidatedLink {
+  result: ValidatedLinkStatusFailure
+}
+export interface ValidatedLinkWarning extends ValidatedLink {
+  result: ValidatedLinkStatusWarning
+}
+export interface ValidatedLinkSuccess extends ValidatedLink {
+  result: ValidatedLinkStatusSuccess
+}
+
+export const isValidatedLinkFailure = (
+  link: ValidatedLink
+): link is ValidatedLinkFailure => link.result == "invalid"
+
+export const isValidatedLinkWarning = (
+  link: ValidatedLink
+): link is ValidatedLinkWarning =>
+  link.result == "warning" || link.result === "unknown"
+
+export const isValidatedLinkSuccess = (
+  link: ValidatedLink
+): link is ValidatedLinkSuccess =>
+  link.result == "ok" || link.result === "ignored"
+
+export type ValidateLinkContext = {
+  rootRelativePath: string
+  validRelativeFileUrls: string[]
+  collection: DocCollection
+}
+
+/**
+ * Returns a `ValidatedLink` from a `LinKItem`
+ * @param item The link to validate
+ * @param context Additional context that may be needed for validation.
+ * @returns
+ */
+export const validateLink = async (
+  item: LinkItem,
+  context: ValidateLinkContext
+): Promise<ValidatedLink> => {
+  const { href } = item
+
+  if (href.toLowerCase().startsWith("mailto:")) {
+    return {
+      ...item,
+      type: "mailto",
+      result: "ignored",
+    }
+  }
+
+  if (href.startsWith("#")) {
+    return {
+      ...item,
+      type: "hash",
+      result: "ignored",
+    }
+  }
+
+  if (isLinkExternal(href)) {
+    return validateLinkExternal(item, context)
+  }
+
+  return validateLinkInternal(item, context)
+}

--- a/app/cms/doc-validation/webhook-content-check.server.ts
+++ b/app/cms/doc-validation/webhook-content-check.server.ts
@@ -87,6 +87,7 @@ export const contentCheckOnCheckRun = async ({
         // Github supports a max of 50 annotations.
         annotations: getAnnotations(result).slice(0, 49),
       }
+      conclusion = summary.conclusion
     } catch (error) {
       logger.error("Validating check run failed", error)
       const { message } = ensure(error)

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "github-slugger": "^1.4.0",
     "hast-util-to-string": "^2.0.0",
     "ioredis": "^5.0.6",
+    "link-check": "^5.2.0",
     "lodash": "^4.17.21",
     "lodash.debounce": "^4.0.8",
     "lru-cache": "^7.10.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8216,7 +8216,7 @@ debug@4.3.2:
   dependencies:
     ms "2.1.2"
 
-debug@^3.0.0, debug@^3.1.0, debug@^3.2.7:
+debug@^3.0.0, debug@^3.1.0, debug@^3.2.6, debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
@@ -11040,7 +11040,7 @@ iconv-lite@0.4.24, iconv-lite@^0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@0.6.3, iconv-lite@^0.6.2:
+iconv-lite@0.6.3, iconv-lite@^0.6.2, iconv-lite@^0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
   integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
@@ -11248,6 +11248,11 @@ is-absolute-url@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/is-absolute-url/-/is-absolute-url-3.0.3.tgz#96c6a22b6a23929b11ea0afb1836c36ad4a5d698"
   integrity sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q==
+
+is-absolute-url@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/is-absolute-url/-/is-absolute-url-4.0.1.tgz#16e4d487d4fded05cfe0685e53ec86804a5e94dc"
+  integrity sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==
 
 is-accessor-descriptor@^0.1.6:
   version "0.1.6"
@@ -11628,6 +11633,13 @@ is-regex@^1.1.2, is-regex@^1.1.4:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
 
+is-relative-url@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-relative-url/-/is-relative-url-4.0.0.tgz#4d8371999ff6033b76e4d9972fb5bf496fddfa97"
+  integrity sha512-PkzoL1qKAYXNFct5IKdKRH/iBQou/oCC85QhXj6WKtUQBliZ4Yfd3Zk27RHu9KQG8r6zgvAA2AQKC9p+rqTszg==
+  dependencies:
+    is-absolute-url "^4.0.1"
+
 is-set@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/is-set/-/is-set-2.0.2.tgz#90755fa4c2562dc1c5d4024760d6119b94ca18ec"
@@ -11743,6 +11755,13 @@ isarray@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
   integrity sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==
+
+isemail@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/isemail/-/isemail-3.2.0.tgz#59310a021931a9fb06bbb51e155ce0b3f236832c"
+  integrity sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==
+  dependencies:
+    punycode "2.x.x"
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -12579,6 +12598,16 @@ lines-and-columns@^1.1.6:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
+
+link-check@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/link-check/-/link-check-5.2.0.tgz#595a339d305900bed8c1302f4342a29c366bf478"
+  integrity sha512-xRbhYLaGDw7eRDTibTAcl6fXtmUQ13vkezQiTqshHHdGueQeumgxxmQMIOmJYsh2p8BF08t8thhDQ++EAOOq3w==
+  dependencies:
+    is-relative-url "^4.0.0"
+    isemail "^3.2.0"
+    ms "^2.1.3"
+    needle "^3.1.0"
 
 lint-staged@>=10:
   version "13.0.1"
@@ -14088,7 +14117,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@2.1.3, ms@^2.0.0, ms@^2.1.1:
+ms@2.1.3, ms@^2.0.0, ms@^2.1.1, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -14155,6 +14184,15 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
+
+needle@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/needle/-/needle-3.1.0.tgz#3bf5cd090c28eb15644181ab6699e027bd6c53c9"
+  integrity sha512-gCE9weDhjVGCRqS8dwDR/D3GTAeyXLXuqp7I8EzH6DllZGXSUyxuqqLh+YX9rMAWaaTFyVAg6rHGL25dqvczKw==
+  dependencies:
+    debug "^3.2.6"
+    iconv-lite "^0.6.3"
+    sax "^1.2.4"
 
 negotiator@0.6.3, negotiator@^0.6.2:
   version "0.6.3"
@@ -15614,15 +15652,15 @@ punycode@1.3.2:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
   integrity sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==
 
+punycode@2.x.x, punycode@^2.1.0, punycode@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
 punycode@^1.2.4:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
   integrity sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==
-
-punycode@^2.1.0, punycode@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
-  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
 qs@6.10.3:
   version "6.10.3"
@@ -16618,6 +16656,11 @@ sane@^4.0.3:
     micromatch "^3.1.4"
     minimist "^1.1.1"
     walker "~1.0.5"
+
+sax@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
 scheduler@^0.20.2:
   version "0.20.2"


### PR DESCRIPTION
Closes #669 

Checks external links within any "doc collection" modified by a changeset. 

This generates 3 main check response types:

## Success

No problems were found at all; `conclusion` is set to "success" so a green check mark is shown:
    
<img width="902" alt="Screen Shot 2022-10-06 at 9 58 48 AM" src="https://user-images.githubusercontent.com/393220/194340121-032de0eb-cc72-4ace-8b1a-21f3c34c5b82.png">

<img width="884" alt="Screen Shot 2022-10-06 at 9 58 34 AM" src="https://user-images.githubusercontent.com/393220/194340381-3fe5138b-32c8-4d6c-8ac1-111f91d1e58c.png">

## Failure

Something failed (link returned a 404, "internal" link is invalid, compilation failed, etc); `conclusion` is set to "failure" so a red "X" icon is shown and merging is blocked until the failures are fixed:

<img width="856" alt="Screen Shot 2022-10-06 at 9 59 34 AM" src="https://user-images.githubusercontent.com/393220/194340727-b99fa145-bf1d-41b8-bba3-3cab6a65ae5e.png">
<img width="1886" alt="Screen Shot 2022-10-06 at 9 59 26 AM" src="https://user-images.githubusercontent.com/393220/194340769-95fb93d9-8168-492c-ab05-d5cd5e3cd754.png">

## Warning 

An external link returned a non-success code other than 404; `conclusion` is "neutral" so this doesn't block merging and only shows a gray square:

<img width="913" alt="Screen Shot 2022-10-06 at 10 11 42 AM" src="https://user-images.githubusercontent.com/393220/194340937-4f2f6700-056b-4fc3-9db1-532595c4d303.png">
<img width="1235" alt="Screen Shot 2022-10-06 at 10 11 35 AM" src="https://user-images.githubusercontent.com/393220/194340964-89718982-5226-449b-8450-d3951ab0b3ce.png">


# Additional Notes

- Initially tried using `fetch` with `HEAD` requests but this seemed to be causing issues with the response not being cleaned up correctly and it was crashing the app. I switched to the `link-check` library because it handles 429 automatically (and we _do_ see these from Github during checks), performs HEAD requests by default, and seems to clean-up after itself correctly.  The only downside is there are no type definitions so I had to write those.
- We only consider 404 responses as failures. Any other non 2xx code is just a warning. 
- I added the ability to "ignore" hosts. My concern here was that people might use example URLs or provide documentation on running things locally, so including something like `http://localhost:4000` would trigger an error (since markdown will automatically convert that to a link). For now it is set to ignore `localhost` and `example.com`.