### PR TITLE
Check for redirects in catch-all route

### DIFF
--- a/app/routes/__docs/$.tsx
+++ b/app/routes/__docs/$.tsx
@@ -10,6 +10,7 @@ import {
   findDocManifest,
   RemoteRepoError,
 } from "../../cms/collections.server"
+import { returnRedirectForRoute } from "../../cms/utils/return-redirect-for-route"
 import { stripTrailingSlashes } from "../../cms/utils/strip-slashes"
 import { SIDEBAR_DROPDOWN_MENU } from "../../data/sidebar-dropdown-menu"
 import AppLink from "../../ui/design-system/src/lib/Components/AppLink"
@@ -36,6 +37,12 @@ export const loader = async ({ params, request }: LoaderArgs) => {
   const path = params["*"]
 
   const url = new URL(request.url)
+
+  const redirectPath = returnRedirectForRoute(url.pathname)
+  if (redirectPath) {
+    return redirect(redirectPath, 301)
+  }
+
   const preview =
     (ENABLE_PREVIEWS && url.searchParams.get("preview")) || undefined
 


### PR DESCRIPTION
Closes #704 

The current redirect is in the loader of the root layout, and this doesn't get "refreshed" when we change location client-side. The catch-all _does_ get rerendered on every page change, so if we redirect here it works as expected.

It feels like there should be a better, "global" way to do this sort of thing, but I wasn't able to find anything in the remix docs that would make this possible/simpler. 