### PR TITLE
add style guide sub section to cadence sidebar

### DIFF
--- a/app/data/doc-collections/cadence.json
+++ b/app/data/doc-collections/cadence.json
@@ -78,6 +78,15 @@
           ]
         },
         {
+          "title": "Project and Style Guides",
+          "items": [
+            {
+              "title": "Style Guide",
+              "href": "cadence/style-guide"
+            }
+          ]
+        },
+        {
           "title": "Cadence",
           "items": [
             {


### PR DESCRIPTION
style guide was added in a previous PR https://github.com/onflow/developer-portal/pull/731

this PR adds style guide sub section to cadence sidebar and link to the page, navigation works like Language and Tutorial links on cadence sidebar.