### PR TITLE
treat mailto links as external links

### DIFF
--- a/app/ui/design-system/src/lib/utils/isLinkExternal.ts
+++ b/app/ui/design-system/src/lib/utils/isLinkExternal.ts
@@ -1,3 +1,3 @@
 export function isLinkExternal(url: string) {
-  return /^(https?:\/\/|www\.)/.test(url)
+  return /^(https?:\/\/|www\.)/.test(url) || /^(mailto:)/.test(url)
 }


### PR DESCRIPTION
closes  #666 


Treat `mailto` links as external links. Added regex for "mailto:" should ignore and not process mailto links
