### PR TITLE
fixed hotjar integration

### DIFF
--- a/app/entry.client.tsx
+++ b/app/entry.client.tsx
@@ -2,7 +2,11 @@ import { RemixBrowser } from "@remix-run/react"
 import { hydrate } from "react-dom"
 import { onCLS, onFID, onLCP, onFCP, onINP, onTTFB } from "web-vitals"
 import { reportWebVitalsToGA } from "./utils/gtags.client"
+import Hotjar from "@hotjar/browser"
 
+const hotjarVersion = 6
+const hotjarsiteid = 3324806
+Hotjar.init(hotjarsiteid, hotjarVersion)
 // TODO: Figure out why this is necessary only for these 3 images.
 // Possibly related to: https://github.com/remix-run/remix/issues/3414
 //

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -4,17 +4,12 @@ import * as Sentry from "@sentry/node"
 import "@sentry/tracing"
 import { renderToString } from "react-dom/server"
 import { getRequiredGlobalEnvVar } from "./cms/helpers"
-import Hotjar from "@hotjar/browser"
 
 Sentry.init({
   ...(process.env.SENTRY_DSN && { dsn: process.env.SENTRY_DSN }),
   tracesSampleRate: 0.3,
   environment: getRequiredGlobalEnvVar("SENTRY_ENV", "development"),
 })
-
-const hotjarVersion = 6
-
-Hotjar.init(parseInt(process.env.HOTJAR_SITE_ID ?? ""), hotjarVersion)
 
 export default function handleRequest(
   request: Request,


### PR DESCRIPTION
- this works but site id is exposed.
- process is undefined in `entrypoint.client.tsx` 