### PR TITLE
adding a new page for node operation called node provisioning

### DIFF
--- a/app/data/doc-collections/nodes.json
+++ b/app/data/doc-collections/nodes.json
@@ -54,6 +54,10 @@
               "href": "node-operation/node-bootstrap"
             },
             {
+              "title": "Node Provisioning",
+              "href": "node-operation/node-provisioning"
+            },
+            {
               "title": "Node Migration",
               "href": "node-operation/node-migration"
             },


### PR DESCRIPTION
Adding a new page (`node-provisioning`) reference to the sidebar under `node-operation`.

Companion PR on the Flow doc site: https://github.com/onflow/flow/pull/1250