### PR TITLE
catch POST requests and not send error to sentry

### DIFF
--- a/app/routes/__docs/$/$.tsx
+++ b/app/routes/__docs/$/$.tsx
@@ -186,6 +186,12 @@ export function CatchBoundary() {
       )
   }
 
+  if (caught.status === 405) {
+    // There is a IT ticket to filter POST traffic #SRE-BR00006732
+    console.log("Post request caused error, Not Supported method")
+    return null
+  }
+
   throw new Error(`Unhandled error: ${caught.status}`)
 }
 


### PR DESCRIPTION
catch post requests until requests can be filtered out before hitting service

IT ticket submitted to get a proxy in front of developer portal to filter out spam requests like POSTs.