### PR TITLE
better output when manifest isn't found

### DIFF
--- a/app/routes/__docs/$.tsx
+++ b/app/routes/__docs/$.tsx
@@ -78,7 +78,7 @@ export const loader = async ({ params, request }: LoaderArgs) => {
   if (docManifest.remoteRepoError) {
     console.log(
       `Remote repository has invalid manifest`,
-      `${collection.source.owner}/${collection.source.name}`,
+      `${collection.source.owner}/${collection.source.name}/${collection.source.rootPath}`,
       docManifest.remoteRepoError
     )
   }


### PR DESCRIPTION
Frequently log statement indicated a manifest file isn't found, need to track them down. Add better logging. 