### PR TITLE
allow table contents to wrap instead of user having to scroll

### DIFF
--- a/app/ui/design-system/styles/mdx.css
+++ b/app/ui/design-system/styles/mdx.css
@@ -4,7 +4,7 @@
   }
 
   & table {
-    @apply block overflow-x-auto whitespace-nowrap rounded-md border-0;
+    @apply block overflow-x-auto rounded-md border-0;
     border-collapse: separate;
     border-spacing: 0;
     position: relative;


### PR DESCRIPTION
allow table contents to wrap instead of user having to scroll

Issue:
![2023-03-22 10 48 06](https://user-images.githubusercontent.com/3970376/226961232-0a3ad710-aa3b-449d-901b-c8fd339819de.gif)

remove white-space: nowrap

![image](https://user-images.githubusercontent.com/3970376/226961578-c7876018-5d40-41fb-a2f7-ee2014fc9e97.png)
