### PR TITLE
adding a side bar item for the new doc page explaining how to query staking rewards

### DIFF
--- a/app/data/doc-collections/nodes__staking.json
+++ b/app/data/doc-collections/nodes__staking.json
@@ -77,6 +77,10 @@
             {
               "title": "Staking Collection Guide",
               "href": "staking-collection"
+            },
+            {
+              "title": "Querying Staking rewards",
+              "href": "staking-rewards"
             }
           ]
         },

--- a/app/data/redirects.ts
+++ b/app/data/redirects.ts
@@ -202,6 +202,7 @@ export const redirects = {
     "/flow/dapp-development/contract-testing",
   "/staking/staking-collection/": "/nodes/staking/staking-collection",
   "/staking/staking-collection": "/nodes/staking/staking-collection",
+  "/staking/staking-rewards": "/nodes/staking/staking-rewards",
   "/fcl/packages/fcl/CHANGELOG": "/tools/fcl-js",
   "/flow-cli/send-signed-transactions/": "/tools/flow-cli/sign-transactions",
   "/flow-go-sdk/building-transactions/": "/tools/flow-go-sdk",


### PR DESCRIPTION
The [PR](https://github.com/onflow/flow/pull/1316) adds a new page to the doc site explaining how to query staking rewards.
This PR adds that new page to the side bar.