### PR TITLE
:rocket: Submit Easinteraction tool (#1005)

### DIFF
--- a/app/data/pages/tools.ts
+++ b/app/data/pages/tools.ts
@@ -44,6 +44,7 @@ import {
   flowviewTool,
   dapperSelfCustodyWallet,
   unitySDK,
+  easiGen,
 } from "../tools"
 
 export const data: ToolsPageProps = {
@@ -64,6 +65,7 @@ export const data: ToolsPageProps = {
     commandLineLinter,
     cdcWebpackPlugin,
     graffleTool,
+    easiGen,
   ],
   wallets: [
     bloctoWallet,

--- a/app/data/tools/index.ts
+++ b/app/data/tools/index.ts
@@ -611,6 +611,22 @@ const unitySDK: Tool = {
     "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/unity/unity-original.svg",
 }
 
+const easiGen: Tool = {
+  repo: {
+    name: "easinteraction-for-cadence",
+    owner: "LemonNekoGH",
+  },
+  title: "Easinteraction",
+  authorIcon: "https://avatars.githubusercontent.com/u/17664845",
+  authorName: "LemonNeko",
+  tags: ["Go", "Cadence", "Code generation"],
+  link: "https://github.com/LemonNekoGH/easinteraction-for-cadence",
+  stars: 5,
+  iconSrc: ToolCliIconSrc,
+  description:
+    "A golang code generator for easier interaction with Cadence contract",
+}
+
 export {
   flowserTool,
   overflowTool,
@@ -654,4 +670,5 @@ export {
   flowviewTool,
   dapperSelfCustodyWallet,
   unitySDK,
+  easiGen,
 }


### PR DESCRIPTION
Use this tool, Golang engineers can only call the API function in generated code, no need to write too many duplicate transaction creation code, and Contract engineers can only prepare some functions in contract as API, no need to write too many transaction/query script. [More
information](https://github.com/LemonNekoGH/easinteraction-for-cadence)